### PR TITLE
Keen client no longer crashes when uploading empty files

### DIFF
--- a/KeenClient/KeenClient.m
+++ b/KeenClient/KeenClient.m
@@ -599,7 +599,7 @@ static BOOL loggingEnabled = NO;
         NSMutableArray *requestArray = [NSMutableArray array];
         // set up the array of file paths
         NSMutableArray *fileArray = [NSMutableArray array];
-        
+
         for (NSString *fileName in files) {
             KCLog(@"Found file: %@/%@", dirName, fileName);
             NSString *filePath = [dirPath stringByAppendingPathComponent:fileName];
@@ -607,16 +607,22 @@ static BOOL loggingEnabled = NO;
             NSData *data = [NSData dataWithContentsOfFile:filePath];
             // deserialize it
             error = nil;
-            NSDictionary *eventDict = [data objectFromJSONDataWithParseOptions:JKParseOptionNone 
-                                                                         error:&error];
-            if (error) {
-                KCLog(@"An error occurred when deserializing a saved event: %@", [error localizedDescription]);
-                continue;
+
+            if ([data length] > 0) {
+                NSDictionary *eventDict = [data objectFromJSONDataWithParseOptions:JKParseOptionNone
+                                                                             error:&error];
+                if (error) {
+                    KCLog(@"An error occurred when deserializing a saved event: %@", [error localizedDescription]);
+                    continue;
+                }
+                // and then add it to the array of events
+                [requestArray addObject:eventDict];
+                // and also to the array of paths
+                [fileArray addObject:filePath];
             }
-            // and then add it to the array of events
-            [requestArray addObject:eventDict];
-            // and also to the array of paths
-            [fileArray addObject:filePath];
+            else {
+                [[NSFileManager defaultManager] removeItemAtPath:filePath error:nil];
+            }
         }
         // and then add the array back to the overall request
         [requestDict setObject:requestArray forKey:dirName];

--- a/KeenClientTests/KeenClientTests.m
+++ b/KeenClientTests/KeenClientTests.m
@@ -589,6 +589,23 @@
     STAssertNotNil(error, @"collection can't be longer than 256 chars");
 }
 
+-(void)testEmptyEventFileUpload {
+    KeenClient *client = [KeenClient sharedClientWithProjectId:@"id" andWriteKey:@"wk" andReadKey:@"rk"];
+
+    [client addEvent:@{@"fixture key" : @"fixture value"} toEventCollection:@"FixtureCollection" error:nil];
+    client.isRunningTests = YES;
+
+    NSFileManager *fileManager = [NSFileManager defaultManager];
+    NSString *directoryForCollection = [self eventDirectoryForCollection:@"FixtureCollection"];
+    NSString *emptyFilePath = [directoryForCollection stringByAppendingPathComponent:@"42"];
+
+    [fileManager createFileAtPath:emptyFilePath contents:[NSData data] attributes:nil];
+
+    [client uploadWithFinishedBlock:nil];
+
+    STAssertFalse([fileManager fileExistsAtPath:emptyFilePath], @"empty event file should be removed");
+}
+
 # pragma mark - test filesystem utility methods
 
 - (NSString *)cacheDirectory {


### PR DESCRIPTION
I've added a simple check to make sure Keen client does not crash when it encounters empty file
