### PR TITLE
Adding errors to the KCLog

### DIFF
--- a/KeenClient/KeenClient.m
+++ b/KeenClient/KeenClient.m
@@ -843,6 +843,7 @@ static BOOL loggingEnabled = NO;
     if (error != NULL) {
         NSDictionary *userInfo = [NSDictionary dictionaryWithObject:errorMessage forKey:NSLocalizedDescriptionKey];
         *error = [NSError errorWithDomain:kKeenErrorDomain code:1 userInfo:userInfo];
+        KCLog(*error);
     }
 }
                     


### PR DESCRIPTION
Proposing to log the errors to the log? Otherwise I don't really see the point of handle error? (it does add a custom description to the error but the error is not logged anywhere?).

I was having a JSON conversion error (one of my properties was a NSURL instead of NSURL absoluteString...) and didn't knew that my event wasn't recorded...? 
