### PR TITLE
Fixed leak when creating an instance of CLLocationManager

### DIFF
--- a/KeenClient/KeenClient.m
+++ b/KeenClient/KeenClient.m
@@ -333,7 +333,7 @@ static BOOL loggingEnabled = NO;
         // set up the location manager
         if (self.locationManager == nil) {
             if ([CLLocationManager locationServicesEnabled]) {
-                self.locationManager = [[CLLocationManager alloc] init];
+                self.locationManager = [[[CLLocationManager alloc] init] autorelease];
                 self.locationManager.delegate = self;
             }
         }


### PR DESCRIPTION
The locationManager is a retained property.
When alloc/init a new CLLocationManager instance its retainCount is 1. When assigning it to a retain property its count will be 2. Only 1 release will take place (on dealloc) and the CLLocationManager is left around having a retainCount of 1.

This is not a major problem because KeenClient is a singleton (and will therefore never dealloc), but for the sake of correctness this pull request.
