### PR TITLE
Fixing leaks

### DIFF
--- a/KeenClient/KeenClient.m
+++ b/KeenClient/KeenClient.m
@@ -537,11 +537,11 @@ static BOOL loggingEnabled = NO;
 }
 
 - (NSMutableDictionary *)makeDictionaryMutable:(NSDictionary *)dict {
-    return [dict mutableCopy];
+    return [[dict mutableCopy] autorelease];
 }
 
 - (NSMutableArray *)makeArrayMutable:(NSArray *)array {
-    return [array mutableCopy];
+    return [[array mutableCopy] autorelease];
 }
 
 - (id)handleInvalidJSONInObject:(id)value {


### PR DESCRIPTION
This was causing leaks every time an event is reported, leaking all the contents in those data structures, which ends up being a lot of memory
