### PR TITLE
Call upload callback block also when no upload was necessary

### DIFF
--- a/KeenClient/KeenClient.h
+++ b/KeenClient/KeenClient.h
@@ -218,6 +218,7 @@ typedef NSDictionary* (^KeenGlobalPropertiesBlock)(NSString *eventCollection);
  will be logged.
  
  @param block The block to be executed once uploading is finished, regardless of whether or not the upload succeeded.
+ The block is also called when no upload was necessary because no events were captured.
  */
 - (void)uploadWithFinishedBlock:(void (^)())block;
 

--- a/KeenClient/KeenClient.m
+++ b/KeenClient/KeenClient.m
@@ -611,17 +611,15 @@ static BOOL loggingEnabled = NO;
         NSData *data = nil;
         NSMutableDictionary *eventPaths = nil;
         [self prepareJSONData:&data andEventPaths:&eventPaths];
-        if (!data || !eventPaths) {
-            return;
+        if ([data length] > 0 && [eventPaths count] > 0) {
+            // then make an http request to the keen server.
+            NSURLResponse *response = nil;
+            NSError *error = nil;
+            NSData *responseData = [self sendEvents:data returningResponse:&response error:&error];
+            
+            // then parse the http response and deal with it appropriately
+            [self handleAPIResponse:response andData:responseData forEventPaths:eventPaths];
         }
-        
-        // then make an http request to the keen server.
-        NSURLResponse *response = nil;
-        NSError *error = nil;
-        NSData *responseData = [self sendEvents:data returningResponse:&response error:&error];
-        
-        // then parse the http response and deal with it appropriately
-        [self handleAPIResponse:response andData:responseData forEventPaths:eventPaths];
         
         // finally, run the user-specific block (if there is one)
         if (block) {


### PR DESCRIPTION
Calling the upload block in all cases (also when no upload was necessary) is useful when you want to schedule the upload when the app enters the background.

In the case where the upload is called on `application:didEnterBackground`, a background task is started.

```
UIBackgroundTaskIdentifier taskId = [application beginBackgroundTaskWithExpirationHandler:^(void) {
    NSLog(@"Background task expired.");
}];

[[KeenClient sharedClient] uploadWithFinishedBlock:^(void) {
    [application endBackgroundTask:taskId];
}];
```

Calling background task `begin` has to be balanced with an `end` call, so I have to make sure that the upload finished block is called in every cases - also when no upload was necessary.
