### PR TITLE
Increment attempts of all events prior to POSTing.

### DIFF
--- a/KeenClient/KeenClient.m
+++ b/KeenClient/KeenClient.m
@@ -812,6 +812,14 @@ static KIOEventStore *eventStore;
         // get data for the API request we'll make
 
         if ([data length] > 0) {
+
+            // loop through events and increment their attempt count
+            for (NSString *collectionName in eventIds) {
+                for (NSNumber *eid in eventIds[collectionName]) {
+                    [eventStore incrementAttempts:eid];
+                }
+            }
+
             // then make an http request to the keen server.
             NSURLResponse *response = nil;
             NSError *error = nil;
@@ -903,8 +911,6 @@ static KIOEventStore *eventStore;
                 if (deleteFile) {
                     [eventStore deleteEvent: eid];
                     KCLog(@"Successfully deleted event: %@", eid);
-                } else {
-                    [eventStore incrementAttempts:eid];
                 }
                 count++;
             }
@@ -914,13 +920,6 @@ static KIOEventStore *eventStore;
         KCLog(@"Response code was NOT 200. It was: %ld", (long)responseCode);
         NSString *responseString = [[NSString alloc] initWithData:responseData encoding:NSUTF8StringEncoding];
         KCLog(@"Response body was: %@", responseString);
-
-        // loop through events and increment their attempt count
-        for (NSString *collectionName in eventIds) {
-            for (NSNumber *eid in eventIds[collectionName]) {
-                [eventStore incrementAttempts:eid];
-            }
-        }
     }
 }
 


### PR DESCRIPTION
Previously, incrementing attempts was performed by looking up event IDs based on
matching indicies in the server response. This could fail if the server returned
a malformed response, or if the client POSTed an event with invalid JSON.
Additionally, if the app was killed during the POSTing process, it would not
count as a failure.

This changes the logic to increment the attempt count immediately prior to
POSTing the event. This should reduce the likelyhood of "poison pill" events
causing infinite loops.
