### PR TITLE
Fixed small warnings on Xcode

### DIFF
--- a/KeenClient/KeenClient.m
+++ b/KeenClient/KeenClient.m
@@ -372,7 +372,7 @@ static KIOEventStore *eventStore;
     // If it's a relatively recent event, turn off updates to save power
     NSDate* eventDate = newLocation.timestamp;
     NSTimeInterval howRecent = [eventDate timeIntervalSinceNow];
-    if (abs(howRecent) < 15.0) {
+    if ((int)fabs(howRecent) < 15.0) {
         KCLog(@"latitude %+.6f, longitude %+.6f\n",
               newLocation.coordinate.latitude,
               newLocation.coordinate.longitude);
@@ -381,7 +381,7 @@ static KIOEventStore *eventStore;
         [self.locationManager stopUpdatingLocation];
         KCLog(@"Done finding location");
     } else {
-        KCLog(@"Event wasn't recent enough: %+.2d", abs(howRecent));
+        KCLog(@"Event wasn't recent enough: %+.2d", (int)fabs(howRecent));
     }
 }
 

--- a/KeenClientTests/KeenClientTests.m
+++ b/KeenClientTests/KeenClientTests.m
@@ -1233,8 +1233,8 @@
     client.isRunningTests = YES;
     
     // result from class method should equal the SDK Version constant
-    STAssertTrue([KeenClient sdkVersion] == kKeenSdkVersion,  @"SDK Version from class method equals the SDK Version constant.");
-    STAssertFalse([KeenClient sdkVersion] != kKeenSdkVersion, @"SDK Version from class method doesn't equal the SDK Version constant.");
+    STAssertTrue([[KeenClient sdkVersion] isEqual:kKeenSdkVersion],  @"SDK Version from class method equals the SDK Version constant.");
+    STAssertFalse(![[KeenClient sdkVersion] isEqual:kKeenSdkVersion], @"SDK Version from class method doesn't equal the SDK Version constant.");
 }
 
 - (void)testSDKVersionInstanceClient {
@@ -1242,8 +1242,8 @@
     client.isRunningTests = YES;
     
     // result from class method should equal the SDK Version constant
-    STAssertTrue([KeenClient sdkVersion] == kKeenSdkVersion,  @"SDK Version from class method equals the SDK Version constant.");
-    STAssertFalse([KeenClient sdkVersion] != kKeenSdkVersion, @"SDK Version from class method doesn't equal the SDK Version constant.");
+    STAssertTrue([[KeenClient sdkVersion] isEqual:kKeenSdkVersion],  @"SDK Version from class method equals the SDK Version constant.");
+    STAssertFalse(![[KeenClient sdkVersion] isEqual:kKeenSdkVersion], @"SDK Version from class method doesn't equal the SDK Version constant.");
 }
 
 # pragma mark - test filesystem utility methods


### PR DESCRIPTION
This PR fixes a few warnings Xcode was throwing regarding string comparison using `==` instead of `isEqual` and using `abs` instead of `fabs` on NSTimeInterval.