### PR TITLE
Fix EXC_BAD_ACCESS on KIOEventStore

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,12 +8,16 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Added Network Reachability check before uploading events and SystemConfiguration framework.
 - Added SQLite database versioning and migration capabilities.
 - Added max number of upload retries to events. The default value is 3 attempts, and it can be changed by setting the `client.maxAttempts` variable.
-- Fixed first-time app startup Cocoa error 260 bug where keenSubDirectories does not exist yet.
 - Added KeenSwiftClientExample project and updated README to include Swift code examples.
+
+### Changed
+- Refactored KIOEventStore to reopen connection to database in case it's closed by a SQLite failure.
 - Updated code to accept all HTTP 2xx status codes.
+
 ### Fixed
-- Fixed Xcode warnings
 - Fixed uploading empty data when requests dictionary was empty. PR #75
+- Fixed first-time app startup Cocoa error 260 bug where keenSubDirectories does not exist yet.
+- Fixed Xcode warnings.
 
 ## [3.2.20] - 2014-11-07
 - Skipped 3.2.19 due to CocoaPods versioning issue.

--- a/KeenClient/KIOEventStore.h
+++ b/KeenClient/KIOEventStore.h
@@ -60,28 +60,29 @@
   */
 - (void)deleteEvent: (NSNumber *)eventId;
 
-/**
- Delete all events from the store
- */
+ /**
+  Delete all events from the store
+  */
 - (void)deleteAllEvents;
 
 
-/**
- Increment the `attempts` column
- */
+ /**
+  Increment the `attempts` column
+  */
 - (void)incrementAttempts: (NSNumber *)eventId;
 
-/**
- Convert an NSDate to ISO-8601 using SQLite (thread safe)
+ /**
+  Convert an NSDate to ISO-8601 using SQLite (thread safe)
  
- @param date A date.
- */
+  @param date A date.
+  */
 - (id)convertNSDateToISO8601:(NSDate *)date;
 
-/**
- Delete events starting at an offset. Helps to keep the "queue" bounded.
+ /**
+  Delete events starting at an offset. Helps to keep the "queue" bounded.
  
- @param offset The offset to start deleting events from.
- */
+  @param offset The offset to start deleting events from.
+  */
 - (void)deleteEventsFromOffset: (NSNumber *)offset;
+
 @end

--- a/KeenClient/KIOEventStore.m
+++ b/KeenClient/KIOEventStore.m
@@ -56,95 +56,309 @@
             }
 
             // Now we'll init prepared statements for all the things we might do.
-
+            
             // This statement inserts events into the table.
-            char *insert_sql = "INSERT INTO events (projectId, collection, eventData, pending, attempts) VALUES (?, ?, ?, 0, 0)";
-            if (keen_io_sqlite3_prepare_v2(keen_dbname, insert_sql, -1, &insert_stmt, NULL) != SQLITE_OK) {
-                [self handleSQLiteFailure:@"prepare insert statement"];
-                [self closeDB];
-            }
+            [self prepareSQLStatement:&insert_stmt sqlQuery:"INSERT INTO events (projectId, collection, eventData, pending, attempts) VALUES (?, ?, ?, 0, 0)" failureMessage:@"prepare insert statement"];
             
             // This statement finds non-pending events in the table.
-            char *find_sql = "SELECT id, collection, eventData FROM events WHERE pending=0 AND projectId=? AND attempts<?";
-            if(keen_io_sqlite3_prepare_v2(keen_dbname, find_sql, -1, &find_stmt, NULL) != SQLITE_OK) {
-                [self handleSQLiteFailure:@"prepare find statement"];
-                [self closeDB];
-            }
-
+            [self prepareSQLStatement:&find_stmt sqlQuery:"SELECT id, collection, eventData FROM events WHERE pending=0 AND projectId=? AND attempts<?" failureMessage:@"prepare find non-pending events statement"];
+            
             // This statement counts the total number of events (pending or not)
-            char *count_all_sql = "SELECT count(*) FROM events WHERE projectId=?";
-            if(keen_io_sqlite3_prepare_v2(keen_dbname, count_all_sql, -1, &count_all_stmt, NULL) != SQLITE_OK) {
-                [self handleSQLiteFailure:@"prepare count all statement"];
-                [self closeDB];
-            }
-
+            [self prepareSQLStatement:&count_all_stmt sqlQuery:"SELECT count(*) FROM events WHERE projectID=?" failureMessage:@"prepare count all events statement"];
+            
             // This statement counts the number of pending events.
-            char *count_pending_sql = "SELECT count(*) FROM events WHERE pending=1 AND projectId=?";
-            if(keen_io_sqlite3_prepare_v2(keen_dbname, count_pending_sql, -1, &count_pending_stmt, NULL) != SQLITE_OK) {
-                [self handleSQLiteFailure:@"prepare count pending statement"];
-                [self closeDB];
-            }
+            [self prepareSQLStatement:&count_pending_stmt sqlQuery:"SELECT count(*) FROM events WHERE pending=1 AND projectId=?" failureMessage:@"prepare count pending events statement"];
 
             // This statement marks an event as pending.
-            char *make_pending_sql = "UPDATE events SET pending=1 WHERE id=?";
-            if(keen_io_sqlite3_prepare_v2(keen_dbname, make_pending_sql, -1, &make_pending_stmt, NULL) != SQLITE_OK) {
-                [self handleSQLiteFailure:@"prepare pending statement"];
-                [self closeDB];
-            }
+            [self prepareSQLStatement:&make_pending_stmt sqlQuery:"UPDATE events SET pending=1 WHERE id=?" failureMessage:@"prepare mark event as pending statement"];
             
             // This statement resets pending events back to normal.
-            char *reset_pending_sql = "UPDATE events SET pending=0 WHERE projectId=?";
-            if(keen_io_sqlite3_prepare_v2(keen_dbname, reset_pending_sql, -1, &reset_pending_stmt, NULL) != SQLITE_OK) {
-                [self handleSQLiteFailure:@"reset pending statement"];
-                [self closeDB];
-            }
+            [self prepareSQLStatement:&reset_pending_stmt sqlQuery:"UPDATE events SET pending=0 WHERE projectId=?" failureMessage:@"prepare reset pending statement"];
 
             // This statement purges all pending events.
-            char *purge_sql = "DELETE FROM events WHERE pending=1 AND projectId=?";
-            if(keen_io_sqlite3_prepare_v2(keen_dbname, purge_sql, -1, &purge_stmt, NULL) != SQLITE_OK) {
-                [self closeDB];
-            }
-
+            [self prepareSQLStatement:&purge_stmt sqlQuery:"DELETE FROM events WHERE pending=1 AND projectId=?" failureMessage:@"prepare purge pending events statement"];
+            
             // This statement deletes a specific event.
-            char *delete_sql = "DELETE FROM events WHERE id=?";
-            if(keen_io_sqlite3_prepare_v2(keen_dbname, delete_sql, -1, &delete_stmt, NULL) != SQLITE_OK) {
-                [self closeDB];
-            }
+            [self prepareSQLStatement:&delete_stmt sqlQuery:"DELETE FROM events WHERE id=?" failureMessage:@"prepare delete specific event statement"];
 
             // This statement deletes all events.
-            char *delete_all_sql = "DELETE FROM events";
-            if(keen_io_sqlite3_prepare_v2(keen_dbname, delete_all_sql, -1, &delete_all_stmt, NULL) != SQLITE_OK) {
-                [self closeDB];
-            }
+            [self prepareSQLStatement:&delete_all_stmt sqlQuery:"DELETE FROM events" failureMessage:@"prepare delete all events statement"];
 
             // This statement deletes old events at a given offset.
-            char *age_out_sql = "DELETE FROM events WHERE id <= (SELECT id FROM events ORDER BY id DESC LIMIT 1 OFFSET ?)";
-            if(keen_io_sqlite3_prepare_v2(keen_dbname, age_out_sql, -1, &age_out_stmt, NULL) != SQLITE_OK) {
-                [self closeDB];
-            }
-
+            [self prepareSQLStatement:&age_out_stmt sqlQuery:"DELETE FROM events WHERE id <= (SELECT id FROM events ORDER BY id DESC LIMIT 1 OFFSET ?)" failureMessage:@"prepare delete old events at offset statement"];
+            
             // This statement increments the attempts count of an event.
-            char *increment_attempt_sql = "UPDATE events SET attempts = attempts + 1 WHERE id=?";
-            if(keen_io_sqlite3_prepare_v2(keen_dbname, increment_attempt_sql, -1, &increment_attempts_statement, NULL) != SQLITE_OK) {
-                [self handleSQLiteFailure:@"prepare increment attempt statement"];
-                [self closeDB];
-            }
+            [self prepareSQLStatement:&increment_attempts_statement sqlQuery:"UPDATE events SET attempts = attempts + 1 WHERE id=?" failureMessage:@"prepare increment attempt statement"];
 
             // This statement deletes events exceeding a max attempt limit.
-            char *delete_too_many_attempts_sql = "DELETE FROM events WHERE attempts >= ?";
-            if(keen_io_sqlite3_prepare_v2(keen_dbname, delete_too_many_attempts_sql, -1, &delete_too_many_attempts_statement, NULL) != SQLITE_OK) {
-                [self closeDB];
-            }
+            [self prepareSQLStatement:&delete_too_many_attempts_statement sqlQuery:"DELETE FROM events WHERE attempts >= ?" failureMessage:@"prepare delete max attempts events statement"];
 
             // This statement converts an NSDate to an ISO-8601 formatted date/time string (we use sqlite because NSDateFormatter isn't thread-safe)
-            char *convert_date_sql = "SELECT strftime('%Y-%m-%dT%H:%M:%S',datetime(?,'unixepoch','localtime'))";
-            if(keen_io_sqlite3_prepare_v2(keen_dbname, convert_date_sql, -1, &convert_date_stmt, NULL) != SQLITE_OK) {
-                [self closeDB];
-            }
+            [self prepareSQLStatement:&convert_date_stmt sqlQuery:"SELECT strftime('%Y-%m-%dT%H:%M:%S',datetime(?,'unixepoch','localtime'))" failureMessage:@"prepare convert date statement"];
         }
     }
     return self;
 }
+
+- (void)prepareSQLStatement:(keen_io_sqlite3_stmt **)sqlStatement sqlQuery:(char *)sqlQuery failureMessage:(NSString *)failureMessage {
+    if(keen_io_sqlite3_prepare_v2(keen_dbname, sqlQuery, -1, sqlStatement, NULL) != SQLITE_OK) {
+        [self handleSQLiteFailure:failureMessage];
+        [self closeDB];
+    }
+}
+
+# pragma mark - Handle Database -
+
+# pragma mark Database Methods
+
+- (BOOL)openDB {
+    __block BOOL wasOpened = NO;
+    NSString *libraryPath = [NSSearchPathForDirectoriesInDomains(NSLibraryDirectory, NSUserDomainMask, YES) objectAtIndex:0];
+    NSString *my_sqlfile = [libraryPath stringByAppendingPathComponent:@"keenEvents.sqlite"];
+    
+    // we're going to use a queue for all database operations, so let's create it
+    self.dbQueue = dispatch_queue_create("io.keen.sqlite", DISPATCH_QUEUE_SERIAL);
+    
+    // we need to wait for the queue to finish because this method has a return value that we're manipulating in the queue
+    dispatch_sync(self.dbQueue, ^{
+        // initialize sqlite ourselves so we can config
+        keen_io_sqlite3_shutdown();
+        keen_io_sqlite3_config(SQLITE_CONFIG_MULTITHREAD);
+        keen_io_sqlite3_initialize();
+        
+        if (keen_io_sqlite3_open([my_sqlfile UTF8String], &keen_dbname) == SQLITE_OK) {
+            wasOpened = YES;
+        } else {
+            [self handleSQLiteFailure:@"create database"];
+        }
+        dbIsOpen = wasOpened;
+    });
+    
+    return wasOpened;
+}
+
+- (void)closeDB {
+    // Free all the prepared statements. This is safe on null pointers.
+    keen_io_sqlite3_finalize(insert_stmt);
+    keen_io_sqlite3_finalize(find_stmt);
+    keen_io_sqlite3_finalize(count_all_stmt);
+    keen_io_sqlite3_finalize(count_pending_stmt);
+    keen_io_sqlite3_finalize(make_pending_stmt);
+    keen_io_sqlite3_finalize(reset_pending_stmt);
+    keen_io_sqlite3_finalize(purge_stmt);
+    keen_io_sqlite3_finalize(delete_stmt);
+    keen_io_sqlite3_finalize(delete_all_stmt);
+    keen_io_sqlite3_finalize(increment_attempts_statement);
+    keen_io_sqlite3_finalize(delete_too_many_attempts_statement);
+    keen_io_sqlite3_finalize(age_out_stmt);
+    keen_io_sqlite3_finalize(convert_date_stmt);
+    
+    // Free our DB. This is safe on null pointers.
+    keen_io_sqlite3_close(keen_dbname);
+    // Reset state in case it matters.
+    dbIsOpen = NO;
+}
+
+- (BOOL)createTable {
+    __block BOOL wasCreated = NO;
+    
+    if (!dbIsOpen) {
+        KCLog(@"DB is closed, skipping createTable");
+        return wasCreated;
+    }
+    
+    // we need to wait for the queue to finish because this method has a return value that we're manipulating in the queue
+    dispatch_sync(self.dbQueue, ^{
+        char *err;
+        NSString *sql = [NSString stringWithFormat:@"CREATE TABLE IF NOT EXISTS 'events' (ID INTEGER PRIMARY KEY AUTOINCREMENT, collection TEXT, projectId TEXT, eventData BLOB, pending INTEGER, dateCreated TIMESTAMP DEFAULT CURRENT_TIMESTAMP);"];
+        if (keen_io_sqlite3_exec(keen_dbname, [sql UTF8String], NULL, NULL, &err) != SQLITE_OK) {
+            KCLog(@"Failed to create table: %@", [NSString stringWithCString:err encoding:NSUTF8StringEncoding]);
+            keen_io_sqlite3_free(err); // Free that error message
+            [self closeDB];
+        } else {
+            wasCreated = YES;
+        }
+    });
+    
+    
+    return wasCreated;
+}
+
+- (int)queryUserVersion {
+    int databaseVersion = 0;
+    
+    // get current database version of schema
+    static keen_io_sqlite3_stmt *stmt_version;
+    
+    if(keen_io_sqlite3_prepare_v2(keen_dbname, "PRAGMA user_version;", -1, &stmt_version, NULL) != SQLITE_OK) {
+        return -1;
+    }
+    
+    while(keen_io_sqlite3_step(stmt_version) == SQLITE_ROW) {
+        databaseVersion = keen_io_sqlite3_column_int(stmt_version, 0);
+    }
+    keen_io_sqlite3_finalize(stmt_version);
+    
+    // -1 means error, >= 1 is a real version number, otherwise it's unversioned
+    if (databaseVersion != -1 && !(databaseVersion >= 1)) {
+        return 0;
+    }
+    
+    return databaseVersion;
+}
+
+- (BOOL)setUserVersion: (int)userVersion {
+    char *err;
+    NSString *sql = [NSString stringWithFormat:@"PRAGMA user_version = %d;", userVersion];
+    if (keen_io_sqlite3_exec(keen_dbname, [sql UTF8String], NULL, NULL, &err) != SQLITE_OK) {
+        KCLog(@"failed to set user_version: %@", [NSString stringWithCString:err encoding:NSUTF8StringEncoding]);
+        keen_io_sqlite3_free(err); // Free that error message
+        return NO;
+    }
+    
+    return YES;
+}
+
+- (BOOL)migrateTable {
+    __block BOOL wasMigrated = NO;
+    
+    if (!dbIsOpen) {
+        KCLog(@"DB is closed, skipping migrateTable");
+        return NO;
+    }
+    
+    // we need to wait for the queue to finish because this method has a return value
+    // that we're manipulating in the queue
+    dispatch_sync(self.dbQueue, ^{
+        int userVersion = [self queryUserVersion];
+        KCLog(@"Preparing to migrate DB, current version: %d", userVersion);
+        wasMigrated = [self migrateFromVersion:userVersion];
+    });
+    
+    return wasMigrated;
+}
+
+-(BOOL)migrateFromVersion: (int)userVersion {
+    // this is really more of a while loop, but we use a for loop with a limit to avoid
+    // getting stuck in an infinite loop if there is a bug in the loop breaking logic
+    for(int i = 0; i < 1000; i++) {
+        if(![self beginTransaction]) {
+            // deal with error?
+            KCLog(@"Migration failed to begin a transaction with userVersion = %d.", userVersion);
+            return NO;
+        }
+        
+        int migrationResult = [self runMigration:userVersion];
+        if (migrationResult == 0) {
+            // we didn't migrate anything, because we're current.
+            return YES;
+        }
+        
+        if (migrationResult < 0) {
+            // error
+            if (![self rollbackTransaction]) {
+                KCLog(@"Migration failed to rollback a transaction with userVersion = %d.", userVersion);
+                // yeesh, couldn't rollback
+            }
+            return NO;
+        }
+        
+        // we migrated, so increment PRAGMA user_version
+        if (![self setUserVersion:userVersion+1]) {
+            KCLog(@"Migration failed to set the user_version to %d.", userVersion);
+            if (![self rollbackTransaction]) {
+                KCLog(@"Migration failed to rollback a transaction after failing to set user_version (with userVersion = %d).", userVersion);
+                // whoa, double bad news
+            }
+            return NO;
+        }
+        // ok, let's commit this step
+        if (![self commitTransaction]) {
+            KCLog(@"Migration failed to commit a transaction with userVersion = %d.", userVersion);
+            return NO;
+        }
+        
+        userVersion++;
+        
+        // there might be more migrations, so we loop around again
+    }
+    
+    KCLog(@"Migration loop maxed out after 1000 iterations. This is almost certainly a bug. Version %d", [self queryUserVersion]);
+    
+    return NO;
+}
+
+- (int)runMigration: (int)forVersion {
+    char *err;
+    
+    if (forVersion < 0) {
+        // versions less than 0 are an error
+        return -1;
+    } else if (forVersion == 0) {
+        // first migration does nothing, just adds adds a real version number (1).
+        return YES;
+    } else if (forVersion == 1) {
+        NSString *sql = @"ALTER TABLE events ADD COLUMN attempts INTEGER DEFAULT 0;";
+        if (keen_io_sqlite3_exec(keen_dbname, [sql UTF8String], NULL, NULL, &err) != SQLITE_OK) {
+            KCLog(@"Failed to add attempts column: %@", [NSString stringWithCString:err encoding:NSUTF8StringEncoding]);
+            keen_io_sqlite3_free(err); // Free that error message
+            return -1;
+        }
+        return YES;
+    } else if (forVersion == 2) {
+        // This is the current version. To add a migration, increment the value of the
+        // RHS of the above if statement and add another else if statement in between
+        // to handle the new version number.
+        // e.g. change `forVersion == 2` to `forVersion == 3`, and then add an
+        // explicit block for handling the forVersion == 2 migration that looks like
+        // the forVersion == 1 block above.
+        
+        // IMPORTANT: never remove any existing migration blocks!
+        
+        return 0;
+    }
+    
+    // versions that aren't integers or are greater than the max version we know about
+    // are errors
+    return -1;
+}
+
+# pragma mark Transaction Methods
+
+- (BOOL)beginTransaction {
+    char *err;
+    NSString *sql = @"BEGIN IMMEDIATE TRANSACTION;";
+    if (keen_io_sqlite3_exec(keen_dbname, [sql UTF8String], NULL, NULL, &err) != SQLITE_OK) {
+        KCLog(@"failed to commit transaction: %@", [NSString stringWithCString:err encoding:NSUTF8StringEncoding]);
+        keen_io_sqlite3_free(err); // Free that error message
+        return NO;
+    }
+    return YES;
+}
+
+- (BOOL)commitTransaction {
+    char *err;
+    NSString *sql = @"COMMIT TRANSACTION;";
+    if (keen_io_sqlite3_exec(keen_dbname, [sql UTF8String], NULL, NULL, &err) != SQLITE_OK) {
+        KCLog(@"failed to commit transaction: %@", [NSString stringWithCString:err encoding:NSUTF8StringEncoding]);
+        keen_io_sqlite3_free(err); // Free that error message
+        return NO;
+    }
+    return YES;
+}
+
+- (BOOL)rollbackTransaction {
+    char *err;
+    NSString *sql = @"ROLLBACK TRANSACTION;";
+    if (keen_io_sqlite3_exec(keen_dbname, [sql UTF8String], NULL, NULL, &err) != SQLITE_OK) {
+        KCLog(@"failed to rollback transaction: %@", [NSString stringWithCString:err encoding:NSUTF8StringEncoding]);
+        keen_io_sqlite3_free(err); // Free that error message
+        return NO;
+    }
+    return YES;
+}
+
+# pragma mark - Handle Events -
 
 - (BOOL)addEvent:(NSData *)eventData collection: (NSString *)coll {
     __block BOOL wasAdded = NO;
@@ -182,10 +396,7 @@
         
         wasAdded = YES;
         
-        // You must reset before the commit happens in SQLite. Doing this now!
-        keen_io_sqlite3_reset(insert_stmt);
-        // Clears off the bindings for future uses.
-        keen_io_sqlite3_clear_bindings(insert_stmt);
+        [self resetSQLiteStatement:insert_stmt];
     });
     
     return wasAdded;
@@ -239,8 +450,7 @@
             }
 
             // Reset the pendifier
-            keen_io_sqlite3_reset(make_pending_stmt);
-            keen_io_sqlite3_clear_bindings(make_pending_stmt);
+            [self resetSQLiteStatement:make_pending_stmt];
 
             if ([events objectForKey:coll] == nil) {
                 // We don't have an entry in the dictionary yet for this collection
@@ -251,9 +461,7 @@
             [[events objectForKey:coll] setObject:data forKey:[NSNumber numberWithUnsignedLongLong:eventId]];
         }
 
-        // Reset things
-        keen_io_sqlite3_reset(find_stmt);
-        keen_io_sqlite3_clear_bindings(find_stmt);
+        [self resetSQLiteStatement:find_stmt];
     });
     
     return events;
@@ -273,8 +481,8 @@
         if (keen_io_sqlite3_step(reset_pending_stmt) != SQLITE_DONE) {
             [self handleSQLiteFailure:@"reset pending events"];
         }
-        keen_io_sqlite3_reset(reset_pending_stmt);
-        keen_io_sqlite3_clear_bindings(reset_pending_stmt);
+
+        [self resetSQLiteStatement:reset_pending_stmt];
     });
 }
 
@@ -310,8 +518,8 @@
         } else {
             [self handleSQLiteFailure:@"get count of pending rows"];
         }
-        keen_io_sqlite3_reset(count_pending_stmt);
-        keen_io_sqlite3_clear_bindings(count_pending_stmt);
+
+        [self resetSQLiteStatement:count_pending_stmt];
     });
     
     return eventCount;
@@ -335,8 +543,8 @@
         } else {
             [self handleSQLiteFailure:@"get count of total rows"];
         }
-        keen_io_sqlite3_reset(count_all_stmt);
-        keen_io_sqlite3_clear_bindings(count_all_stmt);
+
+        [self resetSQLiteStatement:count_all_stmt];
     });
     
     return eventCount;
@@ -356,8 +564,8 @@
         if (keen_io_sqlite3_step(delete_stmt) != SQLITE_DONE) {
             [self handleSQLiteFailure:@"delete event"];
         };
-        keen_io_sqlite3_reset(delete_stmt);
-        keen_io_sqlite3_clear_bindings(delete_stmt);
+
+        [self resetSQLiteStatement:delete_stmt];
     });
 }
 
@@ -372,8 +580,8 @@
         if (keen_io_sqlite3_step(delete_all_stmt) != SQLITE_DONE) {
             [self handleSQLiteFailure:@"delete all events"];
         };
-        keen_io_sqlite3_reset(delete_all_stmt);
-        keen_io_sqlite3_clear_bindings(delete_all_stmt);
+
+        [self resetSQLiteStatement:delete_all_stmt];
     });
 }
 
@@ -391,8 +599,8 @@
         if (keen_io_sqlite3_step(age_out_stmt) != SQLITE_DONE) {
             [self handleSQLiteFailure:@"delete all events"];
         };
-        keen_io_sqlite3_reset(age_out_stmt);
-        keen_io_sqlite3_clear_bindings(age_out_stmt);
+
+        [self resetSQLiteStatement:age_out_stmt];
     });
 }
 
@@ -411,9 +619,8 @@
         if (keen_io_sqlite3_step(increment_attempts_statement) != SQLITE_DONE) {
             [self handleSQLiteFailure:@"increment attempts"];
         };
-        keen_io_sqlite3_reset(increment_attempts_statement);
-        keen_io_sqlite3_clear_bindings(increment_attempts_statement);
 
+        [self resetSQLiteStatement:increment_attempts_statement];
     });
 }
 
@@ -432,260 +639,21 @@
             [self handleSQLiteFailure:@"purge pending events"];
             // XXX What to do here?
         };
-        keen_io_sqlite3_reset(purge_stmt);
-        keen_io_sqlite3_clear_bindings(purge_stmt);
+
+        [self resetSQLiteStatement:purge_stmt];
     });
 }
 
-- (BOOL)openDB {
-    __block BOOL wasOpened = NO;
-    NSString *libraryPath = [NSSearchPathForDirectoriesInDomains(NSLibraryDirectory, NSUserDomainMask, YES) objectAtIndex:0];
-    NSString *my_sqlfile = [libraryPath stringByAppendingPathComponent:@"keenEvents.sqlite"];
-    
-    // we're going to use a queue for all database operations, so let's create it
-    self.dbQueue = dispatch_queue_create("io.keen.sqlite", DISPATCH_QUEUE_SERIAL);
-    
-    // we need to wait for the queue to finish because this method has a return value that we're manipulating in the queue
-    dispatch_sync(self.dbQueue, ^{
-        // initialize sqlite ourselves so we can config
-        keen_io_sqlite3_shutdown();
-        keen_io_sqlite3_config(SQLITE_CONFIG_MULTITHREAD);
-        keen_io_sqlite3_initialize();
-        
-        if (keen_io_sqlite3_open([my_sqlfile UTF8String], &keen_dbname) == SQLITE_OK) {
-            wasOpened = YES;
-        } else {
-            [self handleSQLiteFailure:@"create database"];
-        }
-        dbIsOpen = wasOpened;
-    });
-    
-    return wasOpened;
-}
+# pragma mark - Helper Methods -
 
-- (BOOL)createTable {
-    __block BOOL wasCreated = NO;
-
-    if (!dbIsOpen) {
-        KCLog(@"DB is closed, skipping createTable");
-        return wasCreated;
-    }
-    
-    // we need to wait for the queue to finish because this method has a return value that we're manipulating in the queue
-    dispatch_sync(self.dbQueue, ^{
-        char *err;
-        NSString *sql = [NSString stringWithFormat:@"CREATE TABLE IF NOT EXISTS 'events' (ID INTEGER PRIMARY KEY AUTOINCREMENT, collection TEXT, projectId TEXT, eventData BLOB, pending INTEGER, dateCreated TIMESTAMP DEFAULT CURRENT_TIMESTAMP);"];
-        if (keen_io_sqlite3_exec(keen_dbname, [sql UTF8String], NULL, NULL, &err) != SQLITE_OK) {
-            KCLog(@"Failed to create table: %@", [NSString stringWithCString:err encoding:NSUTF8StringEncoding]);
-            keen_io_sqlite3_free(err); // Free that error message
-            [self closeDB];
-        } else {
-            wasCreated = YES;
-        }
-    });
-
-
-    return wasCreated;
-}
-
-- (int)queryUserVersion {
-    int databaseVersion = 0;
-
-    // get current database version of schema
-    static keen_io_sqlite3_stmt *stmt_version;
-
-    if(keen_io_sqlite3_prepare_v2(keen_dbname, "PRAGMA user_version;", -1, &stmt_version, NULL) != SQLITE_OK) {
-        return -1;
-    }
-
-    while(keen_io_sqlite3_step(stmt_version) == SQLITE_ROW) {
-        databaseVersion = keen_io_sqlite3_column_int(stmt_version, 0);
-    }
-    keen_io_sqlite3_finalize(stmt_version);
-
-    // -1 means error, >= 1 is a real version number, otherwise it's unversioned
-    if (databaseVersion != -1 && !(databaseVersion >= 1)) {
-        return 0;
-    }
-
-    return databaseVersion;
-}
-
-- (BOOL)beginTransaction {
-    char *err;
-    NSString *sql = @"BEGIN IMMEDIATE TRANSACTION;";
-    if (keen_io_sqlite3_exec(keen_dbname, [sql UTF8String], NULL, NULL, &err) != SQLITE_OK) {
-        KCLog(@"failed to commit transaction: %@", [NSString stringWithCString:err encoding:NSUTF8StringEncoding]);
-        keen_io_sqlite3_free(err); // Free that error message
-        return NO;
-    }
-    return YES;
-}
-
-- (BOOL)commitTransaction {
-    char *err;
-    NSString *sql = @"COMMIT TRANSACTION;";
-    if (keen_io_sqlite3_exec(keen_dbname, [sql UTF8String], NULL, NULL, &err) != SQLITE_OK) {
-        KCLog(@"failed to commit transaction: %@", [NSString stringWithCString:err encoding:NSUTF8StringEncoding]);
-        keen_io_sqlite3_free(err); // Free that error message
-        return NO;
-    }
-    return YES;
-}
-
-- (BOOL)rollbackTransaction {
-    char *err;
-    NSString *sql = @"ROLLBACK TRANSACTION;";
-    if (keen_io_sqlite3_exec(keen_dbname, [sql UTF8String], NULL, NULL, &err) != SQLITE_OK) {
-        KCLog(@"failed to rollback transaction: %@", [NSString stringWithCString:err encoding:NSUTF8StringEncoding]);
-        keen_io_sqlite3_free(err); // Free that error message
-        return NO;
-    }
-    return YES;
-}
-
-- (BOOL)setUserVersion: (int)userVersion {
-    char *err;
-    NSString *sql = [NSString stringWithFormat:@"PRAGMA user_version = %d;", userVersion];
-    if (keen_io_sqlite3_exec(keen_dbname, [sql UTF8String], NULL, NULL, &err) != SQLITE_OK) {
-        KCLog(@"failed to set user_version: %@", [NSString stringWithCString:err encoding:NSUTF8StringEncoding]);
-        keen_io_sqlite3_free(err); // Free that error message
-        return NO;
-    }
-
-    return YES;
-}
-
-- (int)runMigration: (int)forVersion {
-    char *err;
-
-    if (forVersion < 0) {
-        // versions less than 0 are an error
-        return -1;
-    } else if (forVersion == 0) {
-        // first migration does nothing, just adds adds a real version number (1).
-        return YES;
-    } else if (forVersion == 1) {
-        NSString *sql = @"ALTER TABLE events ADD COLUMN attempts INTEGER DEFAULT 0;";
-        if (keen_io_sqlite3_exec(keen_dbname, [sql UTF8String], NULL, NULL, &err) != SQLITE_OK) {
-            KCLog(@"Failed to add attempts column: %@", [NSString stringWithCString:err encoding:NSUTF8StringEncoding]);
-            keen_io_sqlite3_free(err); // Free that error message
-            return -1;
-        }
-        return YES;
-    } else if (forVersion == 2) {
-        // This is the current version. To add a migration, increment the value of the
-        // RHS of the above if statement and add another else if statement in between
-        // to handle the new version number.
-        // e.g. change `forVersion == 2` to `forVersion == 3`, and then add an
-        // explicit block for handling the forVersion == 2 migration that looks like
-        // the forVersion == 1 block above.
-
-        // IMPORTANT: never remove any existing migration blocks!
-
-        return 0;
-    }
-
-    // versions that aren't integers or are greater than the max version we know about
-    // are errors
-    return -1;
-}
-
--(BOOL)migrateFromVersion: (int)userVersion {
-    // this is really more of a while loop, but we use a for loop with a limit to avoid
-    // getting stuck in an infinite loop if there is a bug in the loop breaking logic
-    for(int i = 0; i < 1000; i++) {
-        if(![self beginTransaction]) {
-            // deal with error?
-            KCLog(@"Migration failed to begin a transaction with userVersion = %d.", userVersion);
-            return NO;
-        }
-
-        int migrationResult = [self runMigration:userVersion];
-        if (migrationResult == 0) {
-            // we didn't migrate anything, because we're current.
-            return YES;
-        }
-
-        if (migrationResult < 0) {
-            // error
-            if (![self rollbackTransaction]) {
-                KCLog(@"Migration failed to rollback a transaction with userVersion = %d.", userVersion);
-                // yeesh, couldn't rollback
-            }
-            return NO;
-        }
-
-        // we migrated, so increment PRAGMA user_version
-        if (![self setUserVersion:userVersion+1]) {
-            KCLog(@"Migration failed to set the user_version to %d.", userVersion);
-            if (![self rollbackTransaction]) {
-                KCLog(@"Migration failed to rollback a transaction after failing to set user_version (with userVersion = %d).", userVersion);
-                // whoa, double bad news
-            }
-            return NO;
-        }
-        // ok, let's commit this step
-        if (![self commitTransaction]) {
-            KCLog(@"Migration failed to commit a transaction with userVersion = %d.", userVersion);
-            return NO;
-        }
-
-        userVersion++;
-
-        // there might be more migrations, so we loop around again
-    }
-
-    KCLog(@"Migration loop maxed out after 1000 iterations. This is almost certainly a bug. Version %d", [self queryUserVersion]);
-
-    return NO;
-}
-
-- (BOOL)migrateTable {
-    __block BOOL wasMigrated = NO;
-
-    if (!dbIsOpen) {
-        KCLog(@"DB is closed, skipping migrateTable");
-        return NO;
-    }
-
-    // we need to wait for the queue to finish because this method has a return value
-    // that we're manipulating in the queue
-    dispatch_sync(self.dbQueue, ^{
-        int userVersion = [self queryUserVersion];
-        KCLog(@"Preparing to migrate DB, current version: %d", userVersion);
-        wasMigrated = [self migrateFromVersion:userVersion];
-    });
-
-    return wasMigrated;
+- (void)resetSQLiteStatement:(keen_io_sqlite3_stmt *)sqliteStatement {
+    keen_io_sqlite3_reset(sqliteStatement);
+    keen_io_sqlite3_clear_bindings(sqliteStatement);
 }
 
 - (void)handleSQLiteFailure: (NSString *) msg {
     NSLog(@"Failed to %@: %@",
           msg, [NSString stringWithCString:keen_io_sqlite3_errmsg(keen_dbname) encoding:NSUTF8StringEncoding]);
-}
-
-- (void)closeDB {
-    // Free all the prepared statements. This is safe on null pointers.
-    keen_io_sqlite3_finalize(insert_stmt);
-    keen_io_sqlite3_finalize(find_stmt);
-    keen_io_sqlite3_finalize(count_all_stmt);
-    keen_io_sqlite3_finalize(count_pending_stmt);
-    keen_io_sqlite3_finalize(make_pending_stmt);
-    keen_io_sqlite3_finalize(reset_pending_stmt);
-    keen_io_sqlite3_finalize(purge_stmt);
-    keen_io_sqlite3_finalize(delete_stmt);
-    keen_io_sqlite3_finalize(delete_all_stmt);
-
-    keen_io_sqlite3_finalize(increment_attempts_statement);
-    keen_io_sqlite3_finalize(delete_too_many_attempts_statement);
-    keen_io_sqlite3_finalize(age_out_stmt);
-    keen_io_sqlite3_finalize(convert_date_stmt);
-    
-    // Free our DB. This is safe on null pointers.
-    keen_io_sqlite3_close(keen_dbname);
-    // Reset state in case it matters.
-    dbIsOpen = NO;
 }
 
 - (id)convertNSDateToISO8601:(id)date {
@@ -741,9 +709,7 @@
         
         iso8601 = [[NSString stringWithUTF8String:(char *)keen_io_sqlite3_column_text(convert_date_stmt, 0)] stringByAppendingString:offsetString];
         
-        // reset things
-        keen_io_sqlite3_reset(convert_date_stmt);
-        keen_io_sqlite3_clear_bindings(convert_date_stmt);
+        [self resetSQLiteStatement:convert_date_stmt];
     });
     
     return iso8601;

--- a/KeenClient/KIOEventStore.m
+++ b/KeenClient/KIOEventStore.m
@@ -159,24 +159,28 @@
         if (keen_io_sqlite3_bind_text(insert_stmt, 1, [self.projectId UTF8String], -1, SQLITE_STATIC) != SQLITE_OK) {
             [self handleSQLiteFailure:@"bind pid to add event statement"];
             [self closeDB];
+            return;
         }
         
         if (keen_io_sqlite3_bind_text(insert_stmt, 2, [coll UTF8String], -1, SQLITE_STATIC) != SQLITE_OK) {
             [self handleSQLiteFailure:@"bind coll to add event statement"];
             [self closeDB];
+            return;
         }
         
         if (keen_io_sqlite3_bind_blob(insert_stmt, 3, [eventData bytes], (int) [eventData length], SQLITE_TRANSIENT) != SQLITE_OK) {
             [self handleSQLiteFailure:@"bind insert statement"];
             [self closeDB];
+            return;
         }
         
         if (keen_io_sqlite3_step(insert_stmt) != SQLITE_DONE) {
             [self handleSQLiteFailure:@"insert event"];
             [self closeDB];
-        } else {
-            wasAdded = YES;
+            return;
         }
+        
+        wasAdded = YES;
         
         // You must reset before the commit happens in SQLite. Doing this now!
         keen_io_sqlite3_reset(insert_stmt);
@@ -726,15 +730,16 @@
         if (keen_io_sqlite3_bind_text(convert_date_stmt, 1, [[NSString stringWithFormat:@"%f", [date timeIntervalSince1970]] UTF8String], -1, SQLITE_STATIC) != SQLITE_OK) {
             [self handleSQLiteFailure:@"bind date to date conversion statement"];
             [self closeDB];
+            return;
         }
         
-        if (keen_io_sqlite3_step(convert_date_stmt) == SQLITE_ROW) {
-            iso8601 = [[NSString stringWithUTF8String:(char *)keen_io_sqlite3_column_text(convert_date_stmt, 0)] stringByAppendingString:offsetString];
-        }
-        else {
+        if (keen_io_sqlite3_step(convert_date_stmt) != SQLITE_ROW) {
             [self handleSQLiteFailure:@"date conversion"];
             [self closeDB];
+            return;
         }
+        
+        iso8601 = [[NSString stringWithUTF8String:(char *)keen_io_sqlite3_column_text(convert_date_stmt, 0)] stringByAppendingString:offsetString];
         
         // reset things
         keen_io_sqlite3_reset(convert_date_stmt);

--- a/KeenClient/KIOEventStore.m
+++ b/KeenClient/KIOEventStore.m
@@ -334,25 +334,21 @@
     dispatch_sync(self.dbQueue, ^{
         if (keen_io_sqlite3_bind_text(insert_stmt, 1, [self.projectId UTF8String], -1, SQLITE_STATIC) != SQLITE_OK) {
             [self handleSQLiteFailure:@"bind pid to add event statement"];
-            [self closeDB];
             return;
         }
         
         if (keen_io_sqlite3_bind_text(insert_stmt, 2, [coll UTF8String], -1, SQLITE_STATIC) != SQLITE_OK) {
             [self handleSQLiteFailure:@"bind coll to add event statement"];
-            [self closeDB];
             return;
         }
         
         if (keen_io_sqlite3_bind_blob(insert_stmt, 3, [eventData bytes], (int) [eventData length], SQLITE_TRANSIENT) != SQLITE_OK) {
             [self handleSQLiteFailure:@"bind insert statement"];
-            [self closeDB];
             return;
         }
         
         if (keen_io_sqlite3_step(insert_stmt) != SQLITE_DONE) {
             [self handleSQLiteFailure:@"insert event"];
-            [self closeDB];
             return;
         }
         
@@ -386,7 +382,6 @@
         
         if(keen_io_sqlite3_bind_int64(find_stmt, 2, maxAttempts) != SQLITE_OK) {
             [self handleSQLiteFailure:@"bind coll to add event statement"];
-            [self closeDB];
         }
 
 
@@ -630,13 +625,11 @@
         // bind
         if (keen_io_sqlite3_bind_text(convert_date_stmt, 1, [[NSString stringWithFormat:@"%f", [date timeIntervalSince1970]] UTF8String], -1, SQLITE_STATIC) != SQLITE_OK) {
             [self handleSQLiteFailure:@"bind date to date conversion statement"];
-            [self closeDB];
             return;
         }
         
         if (keen_io_sqlite3_step(convert_date_stmt) != SQLITE_ROW) {
             [self handleSQLiteFailure:@"date conversion"];
-            [self closeDB];
             return;
         }
         
@@ -662,7 +655,6 @@
 - (void)prepareSQLStatement:(keen_io_sqlite3_stmt **)sqlStatement sqlQuery:(char *)sqlQuery failureMessage:(NSString *)failureMessage {
     if(keen_io_sqlite3_prepare_v2(keen_dbname, sqlQuery, -1, sqlStatement, NULL) != SQLITE_OK) {
         [self handleSQLiteFailure:failureMessage];
-        [self closeDB];
     }
 }
 
@@ -715,6 +707,7 @@
 - (void)handleSQLiteFailure: (NSString *) msg {
     NSLog(@"Failed to %@: %@",
           msg, [NSString stringWithCString:keen_io_sqlite3_errmsg(keen_dbname) encoding:NSUTF8StringEncoding]);
+    [self closeDB];
 }
 
 @end

--- a/KeenClient/KIOEventStore.m
+++ b/KeenClient/KIOEventStore.m
@@ -685,6 +685,12 @@
 }
 
 - (id)convertNSDateToISO8601:(id)date {
+    __block NSString *iso8601 = nil;
+    if (!dbIsOpen) {
+        KCLog(@"DB is closed, skipping date conversion");
+        return iso8601;
+    }
+    
     double offset = 0.0f;
     if([date isKindOfClass:[NSDate class]]) {
         offset = [[NSTimeZone localTimeZone] secondsFromGMTForDate:date] / 3600.00;  // need the offset
@@ -715,7 +721,6 @@
         offsetString = [@"-" stringByAppendingString:offsetString];
     }
     
-    __block NSString *iso8601 = nil;
     dispatch_sync(self.dbQueue, ^{
         // bind
         if (keen_io_sqlite3_bind_text(convert_date_stmt, 1, [[NSString stringWithFormat:@"%f", [date timeIntervalSince1970]] UTF8String], -1, SQLITE_STATIC) != SQLITE_OK) {

--- a/KeenClientTests/KIOEventStoreTests.m
+++ b/KeenClientTests/KIOEventStoreTests.m
@@ -172,7 +172,6 @@
     [store closeDB];
 
     // Verify that these methods all behave with a closed database.
-
     STAssertFalse([store hasPendingEvents], @"no pending if closed");
     [store resetPendingEvents]; // This shouldn't crash. :P
     STAssertFalse([store addEvent:[@"POOP" dataUsingEncoding:NSUTF8StringEncoding] collection: @"foo"], @"add event should fail if closed");

--- a/KeenClientTests/KIOEventStoreTests.m
+++ b/KeenClientTests/KIOEventStoreTests.m
@@ -174,10 +174,6 @@
     // Verify that these methods all behave with a closed database.
     STAssertFalse([store hasPendingEvents], @"no pending if closed");
     [store resetPendingEvents]; // This shouldn't crash. :P
-    STAssertFalse([store addEvent:[@"POOP" dataUsingEncoding:NSUTF8StringEncoding] collection: @"foo"], @"add event should fail if closed");
-    STAssertTrue([[store getEventsWithMaxAttempts:3] count] == 0, @"no events if closed");
-    STAssertTrue([store getPendingEventCount] == 0, @"no pending if closed");
-    STAssertTrue([store getTotalEventCount] == 0, @"no total if closed");
     [store purgePendingEvents]; // This shouldn't crash. :P
 }
 


### PR DESCRIPTION
This is related to #79.

This PR adds two things to the KIOEventStore class:

- Adds a check to `convertNSDateToISO8601` to see if the database connection is still open, so it won't call any of the sqlite methods in case it isn't.
- Adds a `return` after all calls to `[self closeDB]` that have a call to `sqlite3_reset` and `sqlite3_clear_bindings` afterwards. The first method calls `sqlite3_finalize` on all pointers, which in turn makes any calls to both of those methods afterward raise an EXC_BAD_ACCESS error.

You can test the first change by forcing a call to `[self closeDB]` and then calling `addEvent` on an instance of KeenClient again. And you can test the second change by forcing a call to `[self closeDB]` before the call to `sqlite3_reset` or `sqlite3_clear_bindings`.