### PR TITLE
closes #85 HTTP status codes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Added max number of upload retries to events. The default value is 3 attempts, and it can be changed by setting the `client.maxAttempts` variable.
 - Fixed first-time app startup Cocoa error 260 bug where keenSubDirectories does not exist yet.
 - Added KeenSwiftClientExample project and updated README to include Swift code examples.
+- Updated code to accept all HTTP 2xx status codes.
 ### Fixed
 - Fixed Xcode warnings
 

--- a/KeenClient.xcodeproj/project.pbxproj
+++ b/KeenClient.xcodeproj/project.pbxproj
@@ -70,6 +70,8 @@
 		3EE5CA9F1AF069D900D6C48D /* SystemConfiguration.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F4D3B61D1A0D98B4000825FE /* SystemConfiguration.framework */; };
 		3EE5CAA01AF069E300D6C48D /* SystemConfiguration.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F4D3B61D1A0D98B4000825FE /* SystemConfiguration.framework */; };
 		3EE5CAA21AF06A0700D6C48D /* SystemConfiguration.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3EE5CAA11AF06A0700D6C48D /* SystemConfiguration.framework */; };
+		A51E31241B03C6EF00008248 /* HTTPCodes.h in Headers */ = {isa = PBXBuildFile; fileRef = A51E31221B03C6EF00008248 /* HTTPCodes.h */; };
+		A51E31251B03C6EF00008248 /* HTTPCodes.m in Sources */ = {isa = PBXBuildFile; fileRef = A51E31231B03C6EF00008248 /* HTTPCodes.m */; };
 		CA6410D818E37E7C00E53E3C /* KIOEventStore.h in Headers */ = {isa = PBXBuildFile; fileRef = CA6410D618E37E7C00E53E3C /* KIOEventStore.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		CA6410D918E37E7C00E53E3C /* KIOEventStore.m in Sources */ = {isa = PBXBuildFile; fileRef = CA6410D718E37E7C00E53E3C /* KIOEventStore.m */; };
 		CA6410E218E39F3A00E53E3C /* KIOEventStoreTests.m in Sources */ = {isa = PBXBuildFile; fileRef = CA6410E118E39F3A00E53E3C /* KIOEventStoreTests.m */; };
@@ -186,6 +188,8 @@
 		1296397519C10AD200B2B653 /* XCTest.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = XCTest.framework; path = Library/Frameworks/XCTest.framework; sourceTree = DEVELOPER_DIR; };
 		1296398C19C10B8500B2B653 /* Cocoa.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Cocoa.framework; path = Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.9.sdk/System/Library/Frameworks/Cocoa.framework; sourceTree = DEVELOPER_DIR; };
 		3EE5CAA11AF06A0700D6C48D /* SystemConfiguration.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = SystemConfiguration.framework; path = Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.10.sdk/System/Library/Frameworks/SystemConfiguration.framework; sourceTree = DEVELOPER_DIR; };
+		A51E31221B03C6EF00008248 /* HTTPCodes.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = HTTPCodes.h; sourceTree = "<group>"; };
+		A51E31231B03C6EF00008248 /* HTTPCodes.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = HTTPCodes.m; sourceTree = "<group>"; };
 		A58E0C061AF85F3C00DF2B71 /* KeenSwiftClientExample.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = KeenSwiftClientExample.xcodeproj; path = KeenSwiftClientExample/KeenSwiftClientExample.xcodeproj; sourceTree = "<group>"; };
 		CA6410D618E37E7C00E53E3C /* KIOEventStore.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = KIOEventStore.h; sourceTree = "<group>"; };
 		CA6410D718E37E7C00E53E3C /* KIOEventStore.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = KIOEventStore.m; sourceTree = "<group>"; wrapsLines = 0; };
@@ -332,6 +336,8 @@
 		017EE12314E30C96000F3868 /* KeenClient */ = {
 			isa = PBXGroup;
 			children = (
+				A51E31221B03C6EF00008248 /* HTTPCodes.h */,
+				A51E31231B03C6EF00008248 /* HTTPCodes.m */,
 				017EE12614E30C96000F3868 /* KeenClient.h */,
 				017EE12714E30C96000F3868 /* KeenClient.m */,
 				012E8A541672B9A90021F6FA /* KeenProperties.h */,
@@ -470,6 +476,7 @@
 				0105EE9A14E9A9C80048D871 /* KeenClient.h in Headers */,
 				012E8A561672B9A90021F6FA /* KeenProperties.h in Headers */,
 				CA6410D818E37E7C00E53E3C /* KIOEventStore.h in Headers */,
+				A51E31241B03C6EF00008248 /* HTTPCodes.h in Headers */,
 				DE34F6F6197586EE00051390 /* keen_io_sqlite3.h in Headers */,
 				DE34F6F9197586EE00051390 /* keen_io_sqlite3ext.h in Headers */,
 				01BA1B0514E895BC00CF9F84 /* KeenConstants.h in Headers */,
@@ -728,6 +735,7 @@
 				CA6410D918E37E7C00E53E3C /* KIOEventStore.m in Sources */,
 				012E8A571672B9A90021F6FA /* KeenProperties.m in Sources */,
 				F4D3B6061A0D8EB4000825FE /* Reachability.m in Sources */,
+				A51E31251B03C6EF00008248 /* HTTPCodes.m in Sources */,
 				DE34F6F3197586EE00051390 /* keen_io_sqlite3.c in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/KeenClient/HTTPCodes.h
+++ b/KeenClient/HTTPCodes.h
@@ -1,0 +1,141 @@
+//
+//  HTTPCode.h
+//
+//  Created by Claire Young on 5/13/15.
+//  Copyright (c) 2012 Keen Labs. All rights reserved.
+//
+//  Most code taken from https://github.com/rafiki270/HTTP-Status-Codes-for-Objective-C
+//  under MIT license: http://www.opensource.org/licenses/mit-license.php
+//  Status codes taken from: http://en.wikipedia.org/wiki/List_of_HTTP_status_codes
+//
+
+#import <Foundation/Foundation.h>
+
+
+typedef NS_ENUM(NSUInteger, HTTPCode) {
+    // Informational
+    HTTPCode1XXInformationalUnknown = 1,
+    HTTPCode100Continue = 100,
+    HTTPCode101SwitchingProtocols = 101,
+    HTTPCode102Processing = 102,
+    
+    // Success
+    HTTPCode2XXSuccessUnknown = 2,
+    HTTPCode200OK = 200,
+    HTTPCode201Created = 201,
+    HTTPCode202Accepted = 202,
+    HTTPCode203NonAuthoritativeInformation = 203,
+    HTTPCode204NoContent = 204,
+    HTTPCode205ResetContent = 205,
+    HTTPCode206PartialContent = 206,
+    HTTPCode207MultiStatus = 207,
+    HTTPCode208AlreadyReported = 208,
+    HTTPCode226IMUsed = 226,
+    
+    // Redirection
+    HTTPCode3XXSuccessUnknown = 3,
+    HTTPCode300MultipleChoices = 300,
+    HTTPCode301MovedPermanently = 301,
+    HTTPCode302Found = 302,
+    HTTPCode303SeeOther = 303,
+    HTTPCode304NotModified = 304,
+    HTTPCode305UseProxy = 305,
+    HTTPCode306SwitchProxy = 306,
+    HTTPCode307TemporaryRedirect = 307,
+    HTTPCode308PermanentRedirect = 308,
+    
+    // Client error
+    HTTPCode4XXSuccessUnknown = 4,
+    HTTPCode400BadRequest = 400,
+    HTTPCode401Unauthorised = 401,
+    HTTPCode402PaymentRequired = 402,
+    HTTPCode403Forbidden = 403,
+    HTTPCode404NotFound = 404,
+    HTTPCode405MethodNotAllowed = 405,
+    HTTPCode406NotAcceptable = 406,
+    HTTPCode407ProxyAuthenticationRequired = 407,
+    HTTPCode408RequestTimeout = 408,
+    HTTPCode409Conflict = 409,
+    HTTPCode410Gone = 410,
+    HTTPCode411LengthRequired = 411,
+    HTTPCode412PreconditionFailed = 412,
+    HTTPCode413RequestEntityTooLarge = 413,
+    HTTPCode414RequestURITooLong = 414,
+    HTTPCode415UnsupportedMediaType = 415,
+    HTTPCode416RequestedRangeNotSatisfiable = 416,
+    HTTPCode417ExpectationFailed = 417,
+    HTTPCode418IamATeapot = 418,
+    HTTPCode419AuthenticationTimeout = 419,
+    HTTPCode420MethodFailureSpringFramework = 420,
+    HTTPCode420EnhanceYourCalmTwitter = 420,
+    HTTPCode421MisdirectedRequest = 421,
+    HTTPCode422UnprocessableEntity = 422,
+    HTTPCode423Locked = 423,
+    HTTPCode424FailedDependency = 424,
+    HTTPCode426UpgradeRequired = 426,
+    HTTPCode428PreconditionRequired = 428,
+    HTTPCode429TooManyRequests = 429,
+    HTTPCode431RequestHeaderFieldsTooLarge = 431,
+    HTTPCode440LoginTimeout = 440,
+    HTTPCode444NoResponseNginx = 444,
+    HTTPCode449RetryWithMicrosoft = 449,
+    HTTPCode450BlockedByWindowsParentalControls = 450,
+    HTTPCode451RedirectMicrosoft = 451,
+    HTTPCode451UnavailableForLegalReasons = 451,
+    HTTPCode494RequestHeaderTooLargeNginx = 494,
+    HTTPCode495CertErrorNginx = 495,
+    HTTPCode496NoCertNginx = 496,
+    HTTPCode497HTTPToHTTPSNginx = 497,
+    HTTPCode498TokenExpiredInvalid = 498,
+    HTTPCode499ClientClosedRequestNginx = 499,
+    HTTPCode499TokenRequiredEsri = 499,
+    
+    
+    // Server error
+    HTTPCode5XXSuccessUnknown = 5,
+    HTTPCode500InternalServerError = 500,
+    HTTPCode501NotImplemented = 501,
+    HTTPCode502BadGateway = 502,
+    HTTPCode503ServiceUnavailable = 503,
+    HTTPCode504GatewayTimeout = 504,
+    HTTPCode505HTTPVersionNotSupported = 505,
+    HTTPCode506VariantAlsoNegotiates = 506,
+    HTTPCode507InsufficientStorage = 507,
+    HTTPCode508LoopDetected = 508,
+    HTTPCode509BandwidthLimitExceeded = 509,
+    HTTPCode510NotExtended = 510,
+    HTTPCode511NetworkAuthenticationRequired = 511,
+    HTTPCode598NetworkReadTimeoutErrorUnknown = 598,
+    HTTPCode599NetworkConnectTimeoutErrorUnknown = 599
+};
+
+typedef NS_ENUM(NSUInteger, HTTPCodeType) {
+    HTTPCodeUnknownType,
+    HTTPCode1XXInformational,
+    HTTPCode2XXSuccess,
+    HTTPCode3XXRedirect,
+    HTTPCode4XXClientError,
+    HTTPCode5XXServerError
+};
+
+@interface HTTPCodes : NSObject
+
+/**
+ *  Return description for a specific HTTP status code
+ *
+ *  @param code Status code definition
+ *
+ *  @return Description
+ */
++ (NSString *)descriptionForCode:(HTTPCode)code;
+
+/**
+ *  Return description for a specific HTTP status code
+ *
+ *  @param code Status code definition
+ *
+ *  @return code type (info, success, redirect, client error, server error, unknown)
+ */
++ (HTTPCodeType)httpCodeType:(HTTPCode)code;
+
+@end

--- a/KeenClient/HTTPCodes.m
+++ b/KeenClient/HTTPCodes.m
@@ -1,0 +1,392 @@
+//
+//  HTTPCodes.m
+//
+//  Created by Claire Young on 5/13/15.
+//  Copyright (c) 2012 Keen Labs. All rights reserved.
+//
+//  Most code taken from https://github.com/rafiki270/HTTP-Status-Codes-for-Objective-C
+//  under MIT license: http://www.opensource.org/licenses/mit-license.php
+//  Status codes taken from: http://en.wikipedia.org/wiki/List_of_HTTP_status_codes
+//
+
+#import "HTTPCodes.h"
+
+
+@implementation HTTPCodes
+
+
+#pragma mark Code descriptions
+
++ (NSString *)descriptionForCode:(HTTPCode)code {
+    
+    NSString *description = [NSString stringWithFormat:@"Unknown status code: %lu", (unsigned long)code];
+    
+    switch (code) {
+            
+            // 1XX Informational
+        case HTTPCode1XXInformationalUnknown:
+            description = @"Undefined 1XX status code";
+            break;
+            
+        case HTTPCode100Continue:
+            description = @"This means that the server has received the request headers, and that the client should proceed to send the request body (in the case of a request for which a body needs to be sent; for example, a POST request). If the request body is large, sending it to a server when a request has already been rejected based upon inappropriate headers is inefficient. To have a server check if the request could be accepted based on the request's headers alone, a client must send Expect: 100-continue as a header in its initial request and check if a 100 Continue status code is received in response before continuing (or receive 417 Expectation Failed and not continue).";
+            break;
+            
+        case HTTPCode101SwitchingProtocols:
+            description = @"This means the requester has asked the server to switch protocols and the server is acknowledging that it will do so.";
+            break;
+            
+        case HTTPCode102Processing:
+            description = @"As a WebDAV request may contain many sub-requests involving file operations, it may take a long time to complete the request. This code indicates that the server has received and is processing the request, but no response is available yet. This prevents the client from timing out and assuming the request was lost.";
+            break;
+            
+            // 2XX Success
+        case HTTPCode2XXSuccessUnknown:
+            description = @"Undefined 2XX status code";
+            break;
+            
+        case HTTPCode200OK:
+            description = @"Standard response for successful HTTP requests. The actual response will depend on the request method used. In a GET request, the response will contain an entity corresponding to the requested resource. In a POST request the response will contain an entity describing or containing the result of the action.";
+            break;
+            
+            
+        case HTTPCode201Created:
+            description = @"The request has been fulfilled and resulted in a new resource being created.";
+            break;
+            
+            
+        case HTTPCode202Accepted:
+            description = @"The request has been accepted for processing, but the processing has not been completed. The request might or might not eventually be acted upon, as it might be disallowed when processing actually takes place.";
+            break;
+            
+            
+        case HTTPCode203NonAuthoritativeInformation:
+            description = @"The server successfully processed the request, but is returning information that may be from another source.";
+            break;
+            
+            
+        case HTTPCode204NoContent:
+            description = @"The server successfully processed the request, but is not returning any content. Usually used as a response to a successful delete request.";
+            break;
+            
+            
+        case HTTPCode205ResetContent:
+            description = @"The server successfully processed the request, but is not returning any content. Unlike a 204 response, this response requires that the requester reset the document view.";
+            break;
+            
+            
+        case HTTPCode206PartialContent:
+            description = @"The server is delivering only part of the resource due to a range header sent by the client. The range header is used by tools like wget to enable resuming of interrupted downloads, or split a download into multiple simultaneous streams.";
+            break;
+            
+            
+        case HTTPCode207MultiStatus:
+            description = @"The message body that follows is an XML message and can contain a number of separate response codes, depending on how many sub-requests were made.";
+            break;
+            
+            
+        case HTTPCode208AlreadyReported:
+            description = @"The members of a DAV binding have already been enumerated in a previous reply to this request, and are not being included again.";
+            break;
+            
+            
+        case HTTPCode226IMUsed:
+            description = @"The server has fulfilled a GET request for the resource, and the response is a representation of the result of one or more instance-manipulations applied to the current instance.";
+            break;
+            
+            
+            // 3XX Success
+        case HTTPCode3XXSuccessUnknown:
+            description = @"Undefined 3XX status code";
+            break;
+            
+        case HTTPCode300MultipleChoices:
+            description = @"Indicates multiple options for the resource that the client may follow. It, for instance, could be used to present different format options for video, list files with different extensions, or word sense disambiguation.";
+            break;
+            
+            
+        case HTTPCode301MovedPermanently:
+            description = @"This and all future requests should be directed to the given URI.";
+            break;
+            
+            
+        case HTTPCode302Found:
+            description = @"This is an example of industry practice contradicting the standard. The HTTP/1.0 specification (RFC 1945) required the client to perform a temporary redirect (the original describing phrase was \"Moved Temporarily\"), but popular browsers implemented 302 with the functionality of a 303 See Other. Therefore, HTTP/1.1 added status codes 303 and 307 to distinguish between the two behaviours. However, some Web applications and frameworks use the 302 status code as if it were the 303.";
+            break;
+            
+            
+        case HTTPCode303SeeOther:
+            description = @"The response to the request can be found under another URI using a GET method. When received in response to a POST (or PUT/DELETE), it should be assumed that the server has received the data and the redirect should be issued with a separate GET message.";
+            break;
+            
+            
+        case HTTPCode304NotModified:
+            description = @"Indicates that the resource has not been modified since the version specified by the request headers If-Modified-Since or If-Match. This means that there is no need to retransmit the resource, since the client still has a previously-downloaded copy.";
+            break;
+            
+            
+        case HTTPCode305UseProxy:
+            description = @"The requested resource is only available through a proxy, whose address is provided in the response. Many HTTP clients (such as Mozilla and Internet Explorer) do not correctly handle responses with this status code, primarily for security reasons.";
+            break;
+            
+            
+        case HTTPCode306SwitchProxy:
+            description = @"No longer used. Originally meant \"Subsequent requests should use the specified proxy.\"";
+            break;
+            
+            
+        case HTTPCode307TemporaryRedirect:
+            description = @"In this case, the request should be repeated with another URI; however, future requests should still use the original URI. In contrast to how 302 was historically implemented, the request method is not allowed to be changed when reissuing the original request. For instance, a POST request should be repeated using another POST request.";
+            break;
+            
+            
+        case HTTPCode308PermanentRedirect:
+            description = @"The request, and all future requests should be repeated using another URI. 307 and 308 (as proposed) parallel the behaviours of 302 and 301, but do not allow the HTTP method to change. So, for example, submitting a form to a permanently redirected resource may continue smoothly.";
+            break;
+            
+            
+            // 4XX Success
+        case HTTPCode4XXSuccessUnknown:
+            description = @"Undefined 4XX status code";
+            break;
+            
+        case HTTPCode400BadRequest:
+            description = @"The request cannot be fulfilled due to bad syntax.";
+            break;
+            
+        case HTTPCode401Unauthorised:
+            description = @"Similar to 403 Forbidden, but specifically for use when authentication is required and has failed or has not yet been provided. The response must include a WWW-Authenticate header field containing a challenge applicable to the requested resource. See Basic access authentication and Digest access authentication.";
+            break;
+            
+        case HTTPCode402PaymentRequired:
+            description = @"Reserved for future use. The original intention was that this code might be used as part of some form of digital cash or micropayment scheme, but that has not happened, and this code is not usually used.";
+            break;
+            
+        case HTTPCode403Forbidden:
+            description = @"The request was a valid request, but the server is refusing to respond to it. Unlike a 401 Unauthorized response, authenticating will make no difference. On servers where authentication is required, this commonly means that the provided credentials were successfully authenticated but that the credentials still do not grant the client permission to access the resource (e.g., a recognized user attempting to access restricted content).";
+            break;
+            
+        case HTTPCode404NotFound:
+            description = @"The requested resource could not be found but may be available again in the future. Subsequent requests by the client are permissible.";
+            break;
+            
+        case HTTPCode405MethodNotAllowed:
+            description = @"A request was made of a resource using a request method not supported by that resource; for example, using GET on a form which requires data to be presented via POST, or using PUT on a read-only resource.";
+            break;
+            
+        case HTTPCode406NotAcceptable:
+            description = @"The requested resource is only capable of generating content not acceptable according to the Accept headers sent in the request.";
+            break;
+            
+        case HTTPCode407ProxyAuthenticationRequired:
+            description = @"The client must first authenticate itself with the proxy.";
+            break;
+            
+        case HTTPCode408RequestTimeout:
+            description = @"The client did not produce a request within the time that the server was prepared to wait. The client MAY repeat the request without modifications at any later time.";
+            break;
+            
+        case HTTPCode409Conflict:
+            description = @"Indicates that the request could not be processed because of conflict in the request, such as an edit conflict in the case of multiple updates.";
+            break;
+            
+        case HTTPCode410Gone:
+            description = @"Indicates that the resource requested is no longer available and will not be available again. This should be used when a resource has been intentionally removed and the resource should be purged. Upon receiving a 410 status code, the client should not request the resource again in the future. Clients such as search engines should remove the resource from their indices. Most use cases do not require clients and search engines to purge the resource, and a \"404 Not Found\" may be used instead.";
+            break;
+            
+        case HTTPCode411LengthRequired:
+            description = @"The request did not specify the length of its content, which is required by the requested resource.";
+            break;
+            
+        case HTTPCode412PreconditionFailed:
+            description = @"The server does not meet one of the preconditions that the requester put on the request.";
+            break;
+            
+        case HTTPCode413RequestEntityTooLarge:
+            description = @"The request is larger than the server is willing or able to process.";
+            break;
+            
+        case HTTPCode414RequestURITooLong:
+            description = @"The URI provided was too long for the server to process. Often the result of too much data being encoded as a query-string of a GET request, in which case it should be converted to a POST request.";
+            break;
+            
+        case HTTPCode415UnsupportedMediaType:
+            description = @"The request entity has a media type which the server or resource does not support. For example, the client uploads an image as image/svg+xml, but the server requires that images use a different format.";
+            break;
+            
+        case HTTPCode416RequestedRangeNotSatisfiable:
+            description = @"The client has asked for a portion of the file, but the server cannot supply that portion. For example, if the client asked for a part of the file that lies beyond the end of the file.";
+            break;
+            
+        case HTTPCode417ExpectationFailed:
+            description = @"The server cannot meet the requirements of the Expect request-header field.";
+            break;
+            
+        case HTTPCode418IamATeapot:
+            description = @"This code was defined in 1998 as one of the traditional IETF April Fools' jokes, in RFC 2324, Hyper Text Coffee Pot Control Protocol, and is not expected to be implemented by actual HTTP servers.";
+            break;
+            
+        case HTTPCode419AuthenticationTimeout:
+            description = @"Not a part of the HTTP standard, 419 Authentication Timeout denotes that previously valid authentication has expired. It is used as an alternative to 401 Unauthorized in order to differentiate from otherwise authenticated clients being denied access to specific server resources";
+            break;
+            
+        case HTTPCode420MethodFailureSpringFramework:
+            description = @"Not part of the HTTP standard, but defined by Spring in the HttpStatus class to be used when a method failed. Or this could be returned by the Twitter Search and Trends API when the client is being rate limited. Other services may wish to implement the 429 Too Many Requests response code instead.";
+            break;
+            
+        case HTTPCode422UnprocessableEntity:
+            description = @"The request was well-formed but was unable to be followed due to semantic errors.";
+            break;
+            
+        case HTTPCode423Locked:
+            description = @"The resource that is being accessed is locked.";
+            break;
+            
+        case HTTPCode424FailedDependency:
+            description = @"The request failed due to failure of a previous request (e.g., a PROPPATCH).";
+            break;
+            
+        case HTTPCode426UpgradeRequired:
+            description = @"The client should switch to a different protocol such as TLS/1.0.";
+            break;
+            
+        case HTTPCode428PreconditionRequired:
+            description = @"The origin server requires the request to be conditional. Intended to prevent \"the 'lost update' problem, where a client GETs a resource's state, modifies it, and PUTs it back to the server, when meanwhile a third party has modified the state on the server, leading to a conflict.\"";
+            break;
+            
+        case HTTPCode429TooManyRequests:
+            description = @"The user has sent too many requests in a given amount of time. Intended for use with rate limiting schemes.";
+            break;
+            
+        case HTTPCode431RequestHeaderFieldsTooLarge:
+            description = @"The server is unwilling to process the request because either an individual header field, or all the header fields collectively, are too large.";
+            break;
+            
+        case HTTPCode440LoginTimeout:
+            description = @"A Microsoft extension. Indicates that your session has expired.";
+            break;
+        case HTTPCode444NoResponseNginx:
+            description = @"Used in Nginx logs to indicate that the server has returned no information to the client and closed the connection (useful as a deterrent for malware).";
+            break;
+            
+        case HTTPCode449RetryWithMicrosoft:
+            description = @"A Microsoft extension. The request should be retried after performing the appropriate action.";
+            break;
+            
+        case HTTPCode450BlockedByWindowsParentalControls:
+            description = @"A Microsoft extension. This error is given when Windows Parental Controls are turned on and are blocking access to the given webpage.";
+            break;
+            
+        case HTTPCode451RedirectMicrosoft:
+            description = @"Used in Exchange ActiveSync if there either is a more efficient server to use or the server can't access the users' mailbox. The client is supposed to re-run the HTTP Autodiscovery protocol to find a better suited server. Or unavailable for legal reasons - Defined in the internet draft \"A New HTTP Status Code for Legally-restricted Resources\". intended to be used when resource access is denied for legal reasons, e.g. censorship or government-mandated blocked access.";
+            break;
+            
+        case HTTPCode494RequestHeaderTooLargeNginx:
+            description = @"Nginx internal code similar to 431 but it was introduced earlier.";
+            break;
+            
+        case HTTPCode495CertErrorNginx:
+            description = @"Nginx internal code used when SSL client certificate error occurred to distinguish it from 4XX in a log and an error page redirection.";
+            break;
+            
+        case HTTPCode496NoCertNginx:
+            description = @"Nginx internal code used when client didn't provide certificate to distinguish it from 4XX in a log and an error page redirection.";
+            break;
+            
+        case HTTPCode497HTTPToHTTPSNginx:
+            description = @"Nginx internal code used for the plain HTTP requests that are sent to HTTPS port to distinguish it from 4XX in a log and an error page redirection.";
+            break;
+        case HTTPCode498TokenExpiredInvalid:
+            description = @"Returned by ArcGIS for Server. A code of 498 indicates an expired or otherwise invalid token.";
+            break;            
+        case HTTPCode499ClientClosedRequestNginx:
+            description = @"Used in Nginx logs to indicate when the connection has been closed by client while the server is still processing its request, making server unable to send a status code back. Or returned by ArcGIS for Server. A code of 499 indicates that a token is required (if no token was submitted).";
+            break;
+            
+            // 5XX Success
+        case HTTPCode5XXSuccessUnknown:
+            description = @"Undefined 5XX status code";
+            break;
+            
+        case HTTPCode500InternalServerError:
+            description = @"A generic error message, given when no more specific message is suitable.";
+            break;
+            
+        case HTTPCode501NotImplemented:
+            description = @"The server either does not recognize the request method, or it lacks the ability to fulfill the request. Usually this implies future availability (e.g., a new feature of a web-service API).";
+            break;
+            
+        case HTTPCode502BadGateway:
+            description = @"The server was acting as a gateway or proxy and received an invalid response from the upstream server.";
+            break;
+            
+        case HTTPCode503ServiceUnavailable:
+            description = @"The server is currently unavailable (because it is overloaded or down for maintenance). Generally, this is a temporary state. Sometimes, this can be permanent as well on test servers.";
+            break;
+            
+        case HTTPCode504GatewayTimeout:
+            description = @"The server was acting as a gateway or proxy and did not receive a timely response from the upstream server.";
+            break;
+            
+        case HTTPCode505HTTPVersionNotSupported:
+            description = @"The server does not support the HTTP protocol version used in the request.";
+            break;
+            
+        case HTTPCode506VariantAlsoNegotiates:
+            description = @"Transparent content negotiation for the request results in a circular reference.";
+            break;
+            
+        case HTTPCode507InsufficientStorage:
+            description = @"The server is unable to store the representation needed to complete the request.";
+            break;
+            
+        case HTTPCode508LoopDetected:
+            description = @"The server detected an infinite loop while processing the request (sent in lieu of 208 Not Reported).";
+            break;
+            
+        case HTTPCode509BandwidthLimitExceeded:
+            description = @"This status code, while used by many servers, is not specified in any RFCs.";
+            break;
+            
+        case HTTPCode510NotExtended:
+            description = @"Further extensions to the request are required for the server to fulfill it.";
+            break;
+            
+        case HTTPCode511NetworkAuthenticationRequired:
+            description = @"The client needs to authenticate to gain network access. Intended for use by intercepting proxies used to control access to the network (e.g., \"captive portals\" used to require agreement to Terms of Service before granting full Internet access via a Wi-Fi hotspot).";
+            break;
+                        
+        case HTTPCode598NetworkReadTimeoutErrorUnknown:
+            description = @"This status code is not specified in any RFCs, but is used by Microsoft HTTP proxies to signal a network read timeout behind the proxy to a client in front of the proxy.";
+            break;
+            
+        case HTTPCode599NetworkConnectTimeoutErrorUnknown:
+            description = @"This status code is not specified in any RFCs, but is used by Microsoft HTTP proxies to signal a network connect timeout behind the proxy to a client in front of the proxy.";
+            break;
+            
+        default:
+            break;
+    }
+    
+    return description;
+}
+
+#pragma mark HTTP Code Types
+
++ (HTTPCodeType)httpCodeType:(HTTPCode)code {
+    if (code >= 100 && code < 200) {
+        return HTTPCode1XXInformational;
+    } else if (code >= 200 && code < 300) {
+        return HTTPCode2XXSuccess;
+    } else if (code >= 300 && code < 400) {
+        return HTTPCode3XXRedirect;
+    } else if (code >= 400 && code < 500) {
+        return HTTPCode4XXClientError;
+    } else if (code >= 500 && code < 600) {
+        return HTTPCode5XXServerError;
+    }
+
+    return HTTPCodeUnknownType;
+}
+
+@end

--- a/KeenClient/KeenClient.m
+++ b/KeenClient/KeenClient.m
@@ -10,6 +10,7 @@
 #import "KeenConstants.h"
 #import "KIOEventStore.h"
 #import "Reachability.h"
+#import "HTTPCodes.h"
 #import <CoreLocation/CoreLocation.h>
 
 
@@ -866,7 +867,7 @@ static KIOEventStore *eventStore;
     }
     NSInteger responseCode = [((NSHTTPURLResponse *)response) statusCode];
     // if the request succeeded, dig into the response to figure out which events succeeded and which failed
-    if (responseCode == 200) {
+    if ([HTTPCodes httpCodeType:(responseCode)] == HTTPCode2XXSuccess) {
         // deserialize the response
         NSError *error = nil;
         NSDictionary *responseDict = [NSJSONSerialization JSONObjectWithData:responseData
@@ -916,8 +917,8 @@ static KIOEventStore *eventStore;
             }
         }
     } else {
-        // response code was NOT 200, which means something else happened. log this.
-        KCLog(@"Response code was NOT 200. It was: %ld", (long)responseCode);
+        // response code was NOT 2xx, which means something else happened. log this.
+        KCLog(@"Response code was NOT 2xx. It was: %ld", (long)responseCode);
         NSString *responseString = [[NSString alloc] initWithData:responseData encoding:NSUTF8StringEncoding];
         KCLog(@"Response body was: %@", responseString);
     }


### PR DESCRIPTION
1. now we handle all 2xx success codes instead of just 200.
2. added all HTTP status codes. NOTE: I copied most of this code from
https://github.com/rafiki270/HTTP-Status-Codes-for-Objective-C, which
is under the MIT license. Is my notation sufficient at the comment at
the top of my .h and .m files?