### PR TITLE
Update README with Reachability instructions for binary installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,8 @@ Uncompress the archive. It should contain a folder called “KeenClient” with 
 
 Drag the "KeenClient" folder into your XCode project.
 
+Make sure you import "KeenClient.h" and "Reachability.h" in your project.
+
 #### CocoaPods
 
 If you're using [CocoaPods](http://cocoapods.org/), add the following to your Podfile:


### PR DESCRIPTION
Small update to the README to avoid confusion if an error occurs about the Reachability.h file not being imported.

Only merge after we update the ZIP binary links. :ship: 