### PR TITLE
Prep for version 3.3.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
 
-## [Unreleased][unreleased]
+## [3.3.0] - 2015-05-27
 ### Added
 - Added Network Reachability check before uploading events and SystemConfiguration framework.
 - Added SQLite database versioning and migration capabilities.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
 
-## [3.3.0] - 2015-05-27
+## [3.3.0](https://github.com/keenlabs/KeenClient-iOS/compare/3.2.20...3.3.0) - 2015-05-27
 ### Added
 - Added Network Reachability check before uploading events and SystemConfiguration framework.
 - Added SQLite database versioning and migration capabilities.

--- a/KeenClient.podspec
+++ b/KeenClient.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |spec|
   spec.name         = 'KeenClient'
-  spec.version      = '3.2.20'
+  spec.version      = '3.3.0'
   spec.license      = { :type => 'MIT' }
   spec.ios.deployment_target = '6.0'
   spec.osx.deployment_target = '10.9'
@@ -10,7 +10,7 @@ Pod::Spec.new do |spec|
   spec.description	= <<-DESC
                       The Keen client is designed to be simple to develop with, yet incredibly flexible.  Our goal is to let you decide what events are important to you, use your own vocabulary to describe them, and decide when you want to send them to Keen service.
                       DESC
-  spec.source       = { :git => 'https://github.com/keenlabs/KeenClient-iOS.git', :tag => '3.2.20' }
+  spec.source       = { :git => 'https://github.com/keenlabs/KeenClient-iOS.git', :tag => '3.3.0' }
   spec.source_files = 'KeenClient/*.{h,m}','Library/sqlite-amalgamation/*.{h,c}','Library/Reachability/*.{h,m}'
   spec.public_header_files = 'KeenClient/*.h'
   spec.private_header_files = 'Library/sqlite-amalgamation/*.h'

--- a/KeenClient/KeenConstants.h
+++ b/KeenClient/KeenConstants.h
@@ -8,7 +8,7 @@
 
 #import <Foundation/Foundation.h>
 
-#define kKeenSdkVersion @"3.2.20"
+#define kKeenSdkVersion @"3.3.0"
 
 extern NSString * const kKeenServerAddress;
 extern NSString * const kKeenApiVersion;

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Keen IO iOS SDK
 
 ---
 
-**Important**: Starting in version 3.21, you'll need to add the SystemConfiguration framework to your project. Check the ["Build Settings"](#build-settings) section for more information.
+**Important**: Starting in version 3.3.0, you'll need to add the SystemConfiguration framework to your project. Check the ["Build Settings"](#build-settings) section for more information.
 
 ---
 
@@ -89,7 +89,10 @@ pod install
 
 ##### Build Settings
 
-Make sure to add CoreLocation.framework and SystemConfiguration.framework to the "Link Binary with Libraries" section.
+Make sure to add the following libraries in the "Link Binary with Libraries" section:
+
+* CoreLocation.framework
+* SystemConfiguration.framework
 
 Also enable the "-ObjC" linker flag under "Other Linker Flags".
 
@@ -506,7 +509,7 @@ You can find the change log [here](CHANGELOG.md).
 
 If you have any questions, bugs, or suggestions, please
 report them via Github Issues. Or, come chat with us anytime
-at [users.keen.io](http://users.keen.io). We'd love to hear your feedback and ideas!
+at [slack.keen.io](http://slack.keen.io). We'd love to hear your feedback and ideas!
 
 ### Contributing
 This is an open source project and we love involvement from the community! Hit us up with pull requests and issues.


### PR DESCRIPTION
* Updated version numbers where appropriate
* Changed chat to point to slack.keen.io instead of users.keen.io