### PR TITLE
Fix sqlite warnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Changed
 - Added the prefix KIO to Reachability files and all its methods to avoid duplicate erros with other projects or Pods. #97
+- Moved sqlite files to a subspec inside the KeenClient.podspec file, and added compiler flags to them to suppress warnings in other projects.
 
 ## [3.3.0](https://github.com/keenlabs/KeenClient-iOS/compare/3.2.20...3.3.0) - 2015-05-27
 ### Added

--- a/KeenClient.podspec
+++ b/KeenClient.podspec
@@ -5,7 +5,14 @@ Pod::Spec.new do |spec|
   spec.ios.deployment_target = '6.0'
   spec.osx.deployment_target = '10.9'
   spec.homepage     = 'https://github.com/keenlabs/KeenClient-iOS'
-  spec.authors      = { 'Daniel Kador' => 'dan@keen.io' }
+  
+  spec.authors      = { 
+    'Daniel Kador'    => 'dan@keen.io',
+    'Terry Horner'    => 'terry@keen.io',
+    'Claire Young'    => 'claire@keen.io',
+    'Heitor Sergent'  => 'heitor@keen.io'
+  }
+  
   spec.summary      = 'Keen iOS client library.'
   spec.description	= <<-DESC
                       The Keen client is designed to be simple to develop with, yet incredibly flexible.  Our goal is to let you decide what events are important to you, use your own vocabulary to describe them, and decide when you want to send them to Keen service.

--- a/KeenClient.podspec
+++ b/KeenClient.podspec
@@ -11,9 +11,14 @@ Pod::Spec.new do |spec|
                       The Keen client is designed to be simple to develop with, yet incredibly flexible.  Our goal is to let you decide what events are important to you, use your own vocabulary to describe them, and decide when you want to send them to Keen service.
                       DESC
   spec.source       = { :git => 'https://github.com/keenlabs/KeenClient-iOS.git', :tag => '3.3.0' }
-  spec.source_files = 'KeenClient/*.{h,m}','Library/sqlite-amalgamation/*.{h,c}','Library/Reachability/*.{h,m}'
+  spec.source_files = 'KeenClient/*.{h,m}','Library/Reachability/*.{h,m}'
   spec.public_header_files = 'KeenClient/*.h'
-  spec.private_header_files = 'Library/sqlite-amalgamation/*.h'
   spec.frameworks   = 'CoreLocation'
   spec.requires_arc = true
+  
+  spec.subspec 'keen_sqlite' do |ks|
+    ks.source_files = 'Library/sqlite-amalgamation/*.{h,c}'
+    ks.private_header_files = 'Library/sqlite-amalgamation/*.h'
+    ks.compiler_flags = '-w', '-Xanalyzer', '-analyzer-disable-all-checks'
+  end
 end

--- a/KeenClient.xcodeproj/project.pbxproj
+++ b/KeenClient.xcodeproj/project.pbxproj
@@ -70,7 +70,7 @@
 		1296399519C10D2C00B2B653 /* KeenProperties.m in Sources */ = {isa = PBXBuildFile; fileRef = 012E8A551672B9A90021F6FA /* KeenProperties.m */; };
 		1296399619C10D2C00B2B653 /* KeenConstants.m in Sources */ = {isa = PBXBuildFile; fileRef = 01BA1B0414E895BC00CF9F84 /* KeenConstants.m */; };
 		1296399719C10D2C00B2B653 /* KIOEventStore.m in Sources */ = {isa = PBXBuildFile; fileRef = CA6410D718E37E7C00E53E3C /* KIOEventStore.m */; };
-		1296399819C10D4000B2B653 /* keen_io_sqlite3.c in Sources */ = {isa = PBXBuildFile; fileRef = DE34F6F0197586EE00051390 /* keen_io_sqlite3.c */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-checker"; }; };
+		1296399819C10D4000B2B653 /* keen_io_sqlite3.c in Sources */ = {isa = PBXBuildFile; fileRef = DE34F6F0197586EE00051390 /* keen_io_sqlite3.c */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
 		3EE5CA9D1AF0697200D6C48D /* SystemConfiguration.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F4D3B61D1A0D98B4000825FE /* SystemConfiguration.framework */; };
 		3EE5CA9F1AF069D900D6C48D /* SystemConfiguration.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F4D3B61D1A0D98B4000825FE /* SystemConfiguration.framework */; };
 		3EE5CAA01AF069E300D6C48D /* SystemConfiguration.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F4D3B61D1A0D98B4000825FE /* SystemConfiguration.framework */; };
@@ -80,9 +80,9 @@
 		CA6410D818E37E7C00E53E3C /* KIOEventStore.h in Headers */ = {isa = PBXBuildFile; fileRef = CA6410D618E37E7C00E53E3C /* KIOEventStore.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		CA6410D918E37E7C00E53E3C /* KIOEventStore.m in Sources */ = {isa = PBXBuildFile; fileRef = CA6410D718E37E7C00E53E3C /* KIOEventStore.m */; };
 		CA6410E218E39F3A00E53E3C /* KIOEventStoreTests.m in Sources */ = {isa = PBXBuildFile; fileRef = CA6410E118E39F3A00E53E3C /* KIOEventStoreTests.m */; };
-		DE34F6F3197586EE00051390 /* keen_io_sqlite3.c in Sources */ = {isa = PBXBuildFile; fileRef = DE34F6F0197586EE00051390 /* keen_io_sqlite3.c */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-checker -Xanalyzer deadcode "; }; };
-		DE34F6F4197586EE00051390 /* keen_io_sqlite3.c in Sources */ = {isa = PBXBuildFile; fileRef = DE34F6F0197586EE00051390 /* keen_io_sqlite3.c */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-checker"; }; };
-		DE34F6F5197586EE00051390 /* keen_io_sqlite3.c in Sources */ = {isa = PBXBuildFile; fileRef = DE34F6F0197586EE00051390 /* keen_io_sqlite3.c */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-checker"; }; };
+		DE34F6F3197586EE00051390 /* keen_io_sqlite3.c in Sources */ = {isa = PBXBuildFile; fileRef = DE34F6F0197586EE00051390 /* keen_io_sqlite3.c */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		DE34F6F4197586EE00051390 /* keen_io_sqlite3.c in Sources */ = {isa = PBXBuildFile; fileRef = DE34F6F0197586EE00051390 /* keen_io_sqlite3.c */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		DE34F6F5197586EE00051390 /* keen_io_sqlite3.c in Sources */ = {isa = PBXBuildFile; fileRef = DE34F6F0197586EE00051390 /* keen_io_sqlite3.c */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
 		DE34F6F6197586EE00051390 /* keen_io_sqlite3.h in Headers */ = {isa = PBXBuildFile; fileRef = DE34F6F1197586EE00051390 /* keen_io_sqlite3.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		DE34F6F7197586EE00051390 /* keen_io_sqlite3.h in Headers */ = {isa = PBXBuildFile; fileRef = DE34F6F1197586EE00051390 /* keen_io_sqlite3.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		DE34F6F8197586EE00051390 /* keen_io_sqlite3.h in Headers */ = {isa = PBXBuildFile; fileRef = DE34F6F1197586EE00051390 /* keen_io_sqlite3.h */; settings = {ATTRIBUTES = (Private, ); }; };


### PR DESCRIPTION
This PR is related to #78.

Move sqlite amalgamation files to a subspec inside the `KeenClient.podspec` file, so we can apply compiler flags to it and suppress the warnings. That way they won't show up when the SDK is being used as part of other projects.

You can test the PR by using a Podfile in a project like this:

```ruby
target 'KeenLibPodsExample' do
  pod 'KeenClient', :path => '~/YOUR/PATH/TO/KeenClient-iOS', :branch => 'fix_sqlite_warnings'
end
```

Then building the project and checking that the Issue navigator doesn't throw any errors.