### PR TITLE
Fix multiple Keen instances upload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,10 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 
 ## [Unreleased][unreleased]
+### Fixed
+- Fixed uploading events with multiple instances of KeenClient. 
 
 ## [3.4.0] - 2015-07-08
-
 ### Added
 - Added querying capability to SDK. 
 

--- a/KeenClient/KIOEventStore.h
+++ b/KeenClient/KIOEventStore.h
@@ -10,19 +10,16 @@
 
 @interface KIOEventStore : NSObject
 
-// The project ID for this store.
-@property (nonatomic, strong) NSString *projectId;
-
  /**
   Reset any pending events so they can be resent.
   */
-- (void)resetPendingEvents;
+- (void)resetPendingEventsWithProjectID:(NSString *)projectID;
 
  /**
   Determine if there are any pending events so the caller can decide what to
   do. See resetPendingEvents or purgePendingEvents.
   */
-- (BOOL)hasPendingEvents;
+- (BOOL)hasPendingEventsWithProjectID:(NSString *)projectID;
 
  /**
   Add an event to the store.
@@ -30,28 +27,28 @@
   @param eventData Your event data.
   @param coll Your event collection.
   */
-- (BOOL)addEvent: (NSData *)eventData collection: (NSString *)coll;
+- (BOOL)addEvent:(NSData *)eventData collection:(NSString *)eventCollection projectID:(NSString *)projectID;
 
  /**
   Get a dictionary of events keyed by id that are ready to send to Keen. Events
   that are returned have been flagged as pending in the underlying store.
   */
-- (NSMutableDictionary *)getEventsWithMaxAttempts: (int)maxAttempts;
+- (NSMutableDictionary *)getEventsWithMaxAttempts:(int)maxAttempts andProjectID:(NSString *)projectID;
 
  /**
   Get a count of pending events.
   */
-- (NSUInteger)getPendingEventCount;
+- (NSUInteger)getPendingEventCountWithProjectID:(NSString *)projectID;
 
  /**
   Get a count of total events, pending or not.
   */
-- (NSUInteger)getTotalEventCount;
+- (NSUInteger)getTotalEventCountWithProjectID:(NSString *)projectID;
 
  /**
   Purge pending events that were returned from a previous call to getEvents.
   */
-- (void)purgePendingEvents;
+- (void)purgePendingEventsWithProjectID:(NSString *)projectID;
 
  /**
   Delete an event from the store

--- a/KeenClient/KIOEventStore.m
+++ b/KeenClient/KIOEventStore.m
@@ -133,7 +133,7 @@
     // we need to wait for the queue to finish because this method has a return value that we're manipulating in the queue
     dispatch_sync(self.dbQueue, ^{
         char *err;
-        NSString *sql = [NSString stringWithFormat:@"CREATE TABLE IF NOT EXISTS 'events' (ID INTEGER PRIMARY KEY AUTOINCREMENT, collection TEXT, projectId TEXT, eventData BLOB, pending INTEGER, dateCreated TIMESTAMP DEFAULT CURRENT_TIMESTAMP);"];
+        NSString *sql = [NSString stringWithFormat:@"CREATE TABLE IF NOT EXISTS 'events' (ID INTEGER PRIMARY KEY AUTOINCREMENT, collection TEXT, projectID TEXT, eventData BLOB, pending INTEGER, dateCreated TIMESTAMP DEFAULT CURRENT_TIMESTAMP);"];
         if (keen_io_sqlite3_exec(keen_dbname, [sql UTF8String], NULL, NULL, &err) != SQLITE_OK) {
             KCLog(@"Failed to create table: %@", [NSString stringWithCString:err encoding:NSUTF8StringEncoding]);
             keen_io_sqlite3_free(err); // Free that error message
@@ -665,25 +665,25 @@
 
 - (void)prepareAllSQLiteStatements {
     // This statement inserts events into the table.
-    [self prepareSQLStatement:&insert_stmt sqlQuery:"INSERT INTO events (projectId, collection, eventData, pending, attempts) VALUES (?, ?, ?, 0, 0)" failureMessage:@"prepare insert statement"];
+    [self prepareSQLStatement:&insert_stmt sqlQuery:"INSERT INTO events (projectID, collection, eventData, pending, attempts) VALUES (?, ?, ?, 0, 0)" failureMessage:@"prepare insert statement"];
     
     // This statement finds non-pending events in the table.
-    [self prepareSQLStatement:&find_stmt sqlQuery:"SELECT id, collection, eventData FROM events WHERE pending=0 AND projectId=? AND attempts<?" failureMessage:@"prepare find non-pending events statement"];
+    [self prepareSQLStatement:&find_stmt sqlQuery:"SELECT id, collection, eventData FROM events WHERE pending=0 AND projectID=? AND attempts<?" failureMessage:@"prepare find non-pending events statement"];
     
     // This statement counts the total number of events (pending or not)
     [self prepareSQLStatement:&count_all_stmt sqlQuery:"SELECT count(*) FROM events WHERE projectID=?" failureMessage:@"prepare count all events statement"];
     
     // This statement counts the number of pending events.
-    [self prepareSQLStatement:&count_pending_stmt sqlQuery:"SELECT count(*) FROM events WHERE pending=1 AND projectId=?" failureMessage:@"prepare count pending events statement"];
+    [self prepareSQLStatement:&count_pending_stmt sqlQuery:"SELECT count(*) FROM events WHERE pending=1 AND projectID=?" failureMessage:@"prepare count pending events statement"];
     
     // This statement marks an event as pending.
     [self prepareSQLStatement:&make_pending_stmt sqlQuery:"UPDATE events SET pending=1 WHERE id=?" failureMessage:@"prepare mark event as pending statement"];
     
     // This statement resets pending events back to normal.
-    [self prepareSQLStatement:&reset_pending_stmt sqlQuery:"UPDATE events SET pending=0 WHERE projectId=?" failureMessage:@"prepare reset pending statement"];
+    [self prepareSQLStatement:&reset_pending_stmt sqlQuery:"UPDATE events SET pending=0 WHERE projectID=?" failureMessage:@"prepare reset pending statement"];
     
     // This statement purges all pending events.
-    [self prepareSQLStatement:&purge_stmt sqlQuery:"DELETE FROM events WHERE pending=1 AND projectId=?" failureMessage:@"prepare purge pending events statement"];
+    [self prepareSQLStatement:&purge_stmt sqlQuery:"DELETE FROM events WHERE pending=1 AND projectID=?" failureMessage:@"prepare purge pending events statement"];
     
     // This statement deletes a specific event.
     [self prepareSQLStatement:&delete_stmt sqlQuery:"DELETE FROM events WHERE id=?" failureMessage:@"prepare delete specific event statement"];

--- a/KeenClient/KeenClient.h
+++ b/KeenClient/KeenClient.h
@@ -21,7 +21,7 @@ typedef NSDictionary* (^KeenGlobalPropertiesBlock)(NSString *eventCollection);
  
  Example usage:
  
-    [KeenClient sharedClientWithProjectId:@"my_project_id" 
+    [KeenClient sharedClientWithProjectID:@"my_project_id"
                               andWriteKey:@"my_write_key" 
                                andReadKey:@"my_read_key"];
     NSDictionary *myEvent = [NSDictionary dictionary];
@@ -110,19 +110,19 @@ typedef NSDictionary* (^KeenGlobalPropertiesBlock)(NSString *eventCollection);
  You'll generally want to call this the first time you ask for the shared client.  Once you've called
  this, you can simply call [KeenClient sharedClient] afterwards.
  
- @param projectId Your Keen IO Project ID.
+ @param projectID Your Keen IO Project ID.
  @param writeKey Your Keen IO Write Key.
  @param readKey Your Keen IO Read Key.
- @return A managed instance of KeenClient, or nil if projectId is invalid.
+ @return A managed instance of KeenClient, or nil if projectID is invalid.
  */
-+ (KeenClient *)sharedClientWithProjectId:(NSString *)projectId andWriteKey:(NSString *)writeKey andReadKey:(NSString *)readKey;
++ (KeenClient *)sharedClientWithProjectID:(NSString *)projectID andWriteKey:(NSString *)writeKey andReadKey:(NSString *)readKey;
 
 /**
  Call this to retrieve the managed instance of KeenClient.
  
  If you only have to use a single Keen project, just use this.
  
- @return A managed instance of KeenClient, or nil if you haven't called [KeenClient sharedClientWithProjectId:andWriteKey:andReadKey:].
+ @return A managed instance of KeenClient, or nil if you haven't called [KeenClient sharedClientWithProjectID:andWriteKey:andReadKey:].
  */
 + (KeenClient *)sharedClient;
 
@@ -194,12 +194,12 @@ typedef NSDictionary* (^KeenGlobalPropertiesBlock)(NSString *eventCollection);
  
  Otherwise, just use [KeenClient sharedClient].
  
- @param projectId Your Keen IO Project ID.
+ @param projectID Your Keen IO Project ID.
  @param writeKey Your Keen IO Write Key.
  @param readKey Your Keen IO Read Key.
  @return An initialized instance of KeenClient.
  */
-- (id)initWithProjectId:(NSString *)projectId andWriteKey:(NSString *)writeKey andReadKey:(NSString *)readKey;
+- (id)initWithProjectID:(NSString *)projectID andWriteKey:(NSString *)writeKey andReadKey:(NSString *)readKey;
 
 /**
  Call this to set the global properties block for this instance of the KeenClient. The block is invoked

--- a/KeenClient/KeenClient.m
+++ b/KeenClient/KeenClient.m
@@ -25,7 +25,7 @@ static KIOEventStore *eventStore;
 @interface KeenClient ()
 
 // The project ID for this particular client.
-@property (nonatomic, strong) NSString *projectId;
+@property (nonatomic, strong) NSString *projectID;
 
 // The Write Key for this particular client.
 @property (nonatomic, strong) NSString *writeKey;
@@ -62,10 +62,10 @@ static KIOEventStore *eventStore;
 
 /**
  Validates that the given project ID is valid.
- @param projectId The Keen project ID.
+ @param projectID The Keen project ID.
  @returns YES if project id is valid, NO otherwise.
  */
-+ (BOOL)validateProjectId:(NSString *)projectId;
++ (BOOL)validateProjectID:(NSString *)projectID;
 
 /**
  Validates that the given key is valid.
@@ -154,7 +154,7 @@ static KIOEventStore *eventStore;
 
 @implementation KeenClient
 
-@synthesize projectId=_projectId;
+@synthesize projectID=_projectID;
 @synthesize writeKey=_writeKey;
 @synthesize readKey=_readKey;
 @synthesize locationManager=_locationManager;
@@ -245,9 +245,9 @@ static KIOEventStore *eventStore;
     return self;
 }
 
-+ (BOOL)validateProjectId:(NSString *)projectId {
++ (BOOL)validateProjectID:(NSString *)projectID {
     // validate that project ID is acceptable
-    if (!projectId || [projectId length] == 0) {
+    if (!projectID || [projectID length] == 0) {
         return NO;
     }
     return YES;
@@ -255,11 +255,11 @@ static KIOEventStore *eventStore;
 
 + (BOOL)validateKey:(NSString *)key {
     // for now just use the same rules as project ID
-    return [KeenClient validateProjectId:key];
+    return [KeenClient validateProjectID:key];
 }
 
-- (id)initWithProjectId:(NSString *)projectId andWriteKey:(NSString *)writeKey andReadKey:(NSString *)readKey {
-    if (![KeenClient validateProjectId:projectId]) {
+- (id)initWithProjectID:(NSString *)projectID andWriteKey:(NSString *)writeKey andReadKey:(NSString *)readKey {
+    if (![KeenClient validateProjectID:projectID]) {
         return nil;
     }
     
@@ -269,7 +269,7 @@ static KIOEventStore *eventStore;
     
     self = [self init];
     if (self) {
-        self.projectId = projectId;
+        self.projectID = projectID;
         if (writeKey) {
             if (![KeenClient validateKey:writeKey]) {
                 return nil;
@@ -289,18 +289,18 @@ static KIOEventStore *eventStore;
 
 # pragma mark - Get a shared client
 
-+ (KeenClient *)sharedClientWithProjectId:(NSString *)projectId andWriteKey:(NSString *)writeKey andReadKey:(NSString *)readKey {
++ (KeenClient *)sharedClientWithProjectID:(NSString *)projectID andWriteKey:(NSString *)writeKey andReadKey:(NSString *)readKey {
     if (!sharedClient) {
         sharedClient = [[KeenClient alloc] init];
     }
-    if (![KeenClient validateProjectId:projectId]) {
+    if (![KeenClient validateProjectID:projectID]) {
         return nil;
     }
 
     if (!eventStore) {
         eventStore = [[KIOEventStore alloc] init];
     }
-    sharedClient.projectId = projectId;
+    sharedClient.projectID = projectID;
 
     if (writeKey) {
         // only validate a non-nil value
@@ -325,7 +325,7 @@ static KIOEventStore *eventStore;
     if (!sharedClient) {
         sharedClient = [[KeenClient alloc] init];
     }
-    if (![KeenClient validateProjectId:sharedClient.projectId]) {
+    if (![KeenClient validateProjectID:sharedClient.projectID]) {
         KCLog(@"sharedClient requested before registering project ID!");
         return nil;
     }
@@ -495,7 +495,7 @@ static KIOEventStore *eventStore;
     event = newEvent;
     
     // now make sure that we haven't hit the max number of events in this collection already
-    NSUInteger eventCount = [eventStore getTotalEventCountWithProjectID:self.projectId];
+    NSUInteger eventCount = [eventStore getTotalEventCountWithProjectID:self.projectID];
     
     // We add 1 because we want to know if this will push us over the limit
     if (eventCount + 1 > self.maxEventsPerCollection) {
@@ -538,7 +538,7 @@ static KIOEventStore *eventStore;
     }
     
     // write JSON to store
-    [eventStore addEvent:jsonData collection: eventCollection projectID:self.projectId];
+    [eventStore addEvent:jsonData collection: eventCollection projectID:self.projectID];
     
     // log the event
     if ([KeenClient isLoggingEnabled]) {
@@ -619,7 +619,7 @@ static KIOEventStore *eventStore;
     NSMutableDictionary *eventIdDict = [NSMutableDictionary dictionary];
     
     // get data for the API request we'll make
-    NSMutableDictionary *events = [eventStore getEventsWithMaxAttempts:self.maxAttempts andProjectID:self.projectId];
+    NSMutableDictionary *events = [eventStore getEventsWithMaxAttempts:self.maxAttempts andProjectID:self.projectID];
     
     NSError *error = nil;
     for (NSString *coll in events) {
@@ -719,7 +719,7 @@ static KIOEventStore *eventStore;
                             KCLog(@"An error occurred when deserializing a saved event: %@", [error localizedDescription]);
                         } else {
                             // All's well: Add it!
-                            [eventStore addEvent:data collection:dirName projectID:self.projectId];
+                            [eventStore addEvent:data collection:dirName projectID:self.projectID];
                         }
 
                     }
@@ -744,7 +744,7 @@ static KIOEventStore *eventStore;
 
 - (NSString *)keenDirectory {
     NSString *keenDirPath = [[self cacheDirectory] stringByAppendingPathComponent:@"keen"];
-    return [keenDirPath stringByAppendingPathComponent:self.projectId];
+    return [keenDirPath stringByAppendingPathComponent:self.projectID];
 }
 
 - (NSArray *)keenSubDirectories {
@@ -939,7 +939,7 @@ static KIOEventStore *eventStore;
 
 - (NSData *)sendEvents:(NSData *)data returningResponse:(NSURLResponse **)response error:(NSError **)error {
     NSString *urlString = [NSString stringWithFormat:@"%@/%@/projects/%@/events",
-                           kKeenServerAddress, kKeenApiVersion, self.projectId];
+                           kKeenServerAddress, kKeenApiVersion, self.projectID];
     KCLog(@"Sending request to: %@", urlString);
     NSURL *url = [NSURL URLWithString:urlString];
     NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:url cachePolicy:NSURLRequestUseProtocolCachePolicy timeoutInterval:30.0f];
@@ -1022,7 +1022,7 @@ static KIOEventStore *eventStore;
 - (NSData *)runQuery:(KIOQuery *)keenQuery returningResponse:(NSURLResponse **)response error:(NSError **)error {
     @synchronized(self) {
         NSString *urlString = [NSString stringWithFormat:@"%@/%@/projects/%@/queries/%@",
-                               kKeenServerAddress, kKeenApiVersion, self.projectId, keenQuery.queryType];
+                               kKeenServerAddress, kKeenApiVersion, self.projectID, keenQuery.queryType];
         KCLog(@"Sending request to: %@", urlString);
         NSURL *url = [NSURL URLWithString:urlString];
         NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:url cachePolicy:NSURLRequestUseProtocolCachePolicy timeoutInterval:30.0f];
@@ -1041,7 +1041,7 @@ static KIOEventStore *eventStore;
 - (NSData *)runMultiAnalysisWithQueries:(NSArray *)keenQueries returningResponse:(NSURLResponse **)response error:(NSError **)error {
     @synchronized(self) {
         NSString *urlString = [NSString stringWithFormat:@"%@/%@/projects/%@/queries/%@",
-                               kKeenServerAddress, kKeenApiVersion, self.projectId, @"multi_analysis"];
+                               kKeenServerAddress, kKeenApiVersion, self.projectID, @"multi_analysis"];
         KCLog(@"Sending request to: %@", urlString);
         
         NSMutableDictionary *analysesDictionary = [[NSMutableDictionary alloc] init];

--- a/KeenClientExample/KeenClientExample/AppDelegate.m
+++ b/KeenClientExample/KeenClientExample/AppDelegate.m
@@ -22,7 +22,7 @@
 - (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions
 {
     [KeenClient enableLogging];
-    KeenClient *client = [KeenClient sharedClientWithProjectId:@"pi" andWriteKey:@"wk" andReadKey:@"rk"];
+    KeenClient *client = [KeenClient sharedClientWithProjectID:@"pi" andWriteKey:@"wk" andReadKey:@"rk"];
     client.globalPropertiesBlock = ^NSDictionary *(NSString *eventCollection) {
         return @{ @"GLOBALS": @"YEAH WHAT"};
     };

--- a/KeenClientTests/KIOEventStoreTests.m
+++ b/KeenClientTests/KIOEventStoreTests.m
@@ -12,11 +12,15 @@
 
 @interface KIOEventStoreTests ()
 
+@property NSString *projectID;
+
 - (NSString *)databaseFile;
 
 @end
 
 @implementation KIOEventStoreTests
+
+@synthesize projectID;
 
 - (void)setUp {
     // Clean up, just in case.
@@ -26,7 +30,9 @@
     } else {
         NSLog(@"Failed to remove database file.");
     }
-
+    
+    projectID = @"pid";
+    
     [super setUp];
 }
 
@@ -46,7 +52,6 @@
 
 - (void)testInit{
     KIOEventStore *store = [[KIOEventStore alloc] init];
-    store.projectId = @"1234";
     XCTAssertNotNil(store, @"init is not null");
     NSString *dbPath = [self databaseFile];
     NSFileManager *fileManager = [NSFileManager defaultManager];
@@ -55,22 +60,20 @@
 
 - (void)testAdd{
     KIOEventStore *store = [[KIOEventStore alloc] init];
-    store.projectId = @"1234";
-    [store addEvent:[@"I AM AN EVENT" dataUsingEncoding:NSUTF8StringEncoding] collection: @"foo"];
-    XCTAssertTrue([store getTotalEventCount] == 1, @"1 total event after add");
-    XCTAssertTrue([store getPendingEventCount] == 0, @"0 pending events after add");
+    [store addEvent:[@"I AM AN EVENT" dataUsingEncoding:NSUTF8StringEncoding] collection:@"foo" projectID:projectID];
+    XCTAssertTrue([store getTotalEventCountWithProjectID:projectID] == 1, @"1 total event after add");
+    XCTAssertTrue([store getPendingEventCountWithProjectID:projectID] == 0, @"0 pending events after add");
 }
 
 - (void)testDelete{
     KIOEventStore *store = [[KIOEventStore alloc] init];
-    store.projectId = @"1234";
-    [store addEvent:[@"I AM AN EVENT" dataUsingEncoding:NSUTF8StringEncoding] collection: @"foo"];
-    XCTAssertTrue([store getTotalEventCount] == 1, @"1 total event after add");
-    XCTAssertTrue([store getPendingEventCount] == 0, @"0 pending events after add");
+    [store addEvent:[@"I AM AN EVENT" dataUsingEncoding:NSUTF8StringEncoding] collection:@"foo" projectID:projectID];
+    XCTAssertTrue([store getTotalEventCountWithProjectID:projectID] == 1, @"1 total event after add");
+    XCTAssertTrue([store getPendingEventCountWithProjectID:projectID] == 0, @"0 pending events after add");
 
     // Lets get some events out now with the purpose of deleteting them.
-    NSMutableDictionary *events = [store getEventsWithMaxAttempts:3];
-    XCTAssertTrue([store getPendingEventCount] == 1, @"1 pending events after getEvents");
+    NSMutableDictionary *events = [store getEventsWithMaxAttempts:3 andProjectID:projectID];
+    XCTAssertTrue([store getPendingEventCountWithProjectID:projectID] == 1, @"1 pending events after getEvents");
 
     for (NSString *coll in events) {
         for (NSNumber *eid in [events objectForKey:coll]) {
@@ -78,103 +81,98 @@
         }
     }
 
-    XCTAssertTrue([store getTotalEventCount] == 0, @"0 total events after delete");
-    XCTAssertTrue([store getPendingEventCount] == 0, @"0 pending events after delete");
+    XCTAssertTrue([store getTotalEventCountWithProjectID:projectID] == 0, @"0 total events after delete");
+    XCTAssertTrue([store getPendingEventCountWithProjectID:projectID] == 0, @"0 pending events after delete");
 }
 
 - (void)testGetPending{
     KIOEventStore *store = [[KIOEventStore alloc] init];
-    store.projectId = @"1234";
-    [store addEvent:[@"I AM AN EVENT" dataUsingEncoding:NSUTF8StringEncoding] collection: @"foo"];
-    [store addEvent:[@"I AM AN EVENT ALSO" dataUsingEncoding:NSUTF8StringEncoding] collection: @"foo"];
+    [store addEvent:[@"I AM AN EVENT" dataUsingEncoding:NSUTF8StringEncoding] collection:@"foo" projectID:projectID];
+    [store addEvent:[@"I AM AN EVENT ALSO" dataUsingEncoding:NSUTF8StringEncoding] collection:@"foo" projectID:projectID];
 
     // Lets get some events out now with the purpose of sending them off.
-    NSMutableDictionary *events = [store getEventsWithMaxAttempts:3];
+    NSMutableDictionary *events = [store getEventsWithMaxAttempts:3 andProjectID:projectID];
 
     XCTAssertTrue([events count] == 1, @"1 collection returned");
     XCTAssertTrue([[events objectForKey:@"foo"] count] == 2, @"2 events returned");
 
-    XCTAssertTrue([store getTotalEventCount] == 2, @"2 total event after add");
-    XCTAssertTrue([store getPendingEventCount] == 2, @"2 pending event after add");
-    XCTAssertTrue([store hasPendingEvents], @"has pending events!");
+    XCTAssertTrue([store getTotalEventCountWithProjectID:projectID] == 2, @"2 total event after add");
+    XCTAssertTrue([store getPendingEventCountWithProjectID:projectID] == 2, @"2 pending event after add");
+    XCTAssertTrue([store hasPendingEventsWithProjectID:projectID], @"has pending events!");
 
-    [store addEvent:[@"I AM NOT AN EVENT BUT A STRING" dataUsingEncoding:NSUTF8StringEncoding] collection: @"foo"];
-    XCTAssertTrue([store getTotalEventCount] == 3, @"3 total event after non-pending add");
-    XCTAssertTrue([store getPendingEventCount] == 2, @"2 pending event after add");
+    [store addEvent:[@"I AM NOT AN EVENT BUT A STRING" dataUsingEncoding:NSUTF8StringEncoding] collection: @"foo" projectID:projectID];
+    XCTAssertTrue([store getTotalEventCountWithProjectID:projectID] == 3, @"3 total event after non-pending add");
+    XCTAssertTrue([store getPendingEventCountWithProjectID:projectID] == 2, @"2 pending event after add");
 }
 
 - (void)testCleanupOfPending{
     KIOEventStore *store = [[KIOEventStore alloc] init];
-    store.projectId = @"1234";
-    [store addEvent:[@"I AM AN EVENT" dataUsingEncoding:NSUTF8StringEncoding] collection: @"foo"];
-    [store addEvent:[@"I AM AN EVENT ALSO" dataUsingEncoding:NSUTF8StringEncoding] collection: @"foo"];
+    [store addEvent:[@"I AM AN EVENT" dataUsingEncoding:NSUTF8StringEncoding] collection:@"foo" projectID:projectID];
+    [store addEvent:[@"I AM AN EVENT ALSO" dataUsingEncoding:NSUTF8StringEncoding] collection:@"foo" projectID:projectID];
 
     // Lets get some events out now with the purpose of sending them off.
-    [store getEventsWithMaxAttempts:3];
+    [store getEventsWithMaxAttempts:3 andProjectID:projectID];
 
-    [store purgePendingEvents];
-    XCTAssertTrue([store getTotalEventCount] == 0, @"0 total event after add");
-    XCTAssertFalse([store hasPendingEvents], @"No pending events now!");
+    [store purgePendingEventsWithProjectID:projectID];
+    XCTAssertTrue([store getTotalEventCountWithProjectID:projectID] == 0, @"0 total event after add");
+    XCTAssertFalse([store hasPendingEventsWithProjectID:projectID], @"No pending events now!");
 
     // Again for good measure
-    [store addEvent:[@"I AM AN EVENT" dataUsingEncoding:NSUTF8StringEncoding] collection: @"foo"];
-    [store addEvent:[@"I AM AN EVENT ALSO" dataUsingEncoding:NSUTF8StringEncoding] collection: @"foo"];
+    [store addEvent:[@"I AM AN EVENT" dataUsingEncoding:NSUTF8StringEncoding] collection:@"foo" projectID:projectID];
+    [store addEvent:[@"I AM AN EVENT ALSO" dataUsingEncoding:NSUTF8StringEncoding] collection:@"foo" projectID:projectID];
 
-    [store getEventsWithMaxAttempts:3];
+    [store getEventsWithMaxAttempts:3 andProjectID:projectID];
 
-    [store purgePendingEvents];
-    XCTAssertTrue([store getTotalEventCount] == 0, @"0 total event after add");
-    XCTAssertFalse([store hasPendingEvents], @"No pending events now!");
+    [store purgePendingEventsWithProjectID:projectID];
+    XCTAssertTrue([store getTotalEventCountWithProjectID:projectID] == 0, @"0 total event after add");
+    XCTAssertFalse([store hasPendingEventsWithProjectID:projectID], @"No pending events now!");
 }
 
 - (void)testResetOfPending{
     KIOEventStore *store = [[KIOEventStore alloc] init];
-    store.projectId = @"1234";
-    [store addEvent:[@"I AM AN EVENT" dataUsingEncoding:NSUTF8StringEncoding] collection: @"foo"];
-    [store addEvent:[@"I AM AN EVENT ALSO" dataUsingEncoding:NSUTF8StringEncoding] collection: @"foo"];
+    [store addEvent:[@"I AM AN EVENT" dataUsingEncoding:NSUTF8StringEncoding] collection:@"foo" projectID:projectID];
+    [store addEvent:[@"I AM AN EVENT ALSO" dataUsingEncoding:NSUTF8StringEncoding] collection:@"foo" projectID:projectID];
 
     // Lets get some events out now with the purpose of sending them off.
-    [store getEventsWithMaxAttempts:3];
-    XCTAssertTrue([store getTotalEventCount] == 2, @"2 total event after add");
-    XCTAssertTrue([store getPendingEventCount] == 2, @"2 pending event after add");
-    XCTAssertTrue([store hasPendingEvents], @"has pending events!");
+    [store getEventsWithMaxAttempts:3 andProjectID:projectID];
+    XCTAssertTrue([store getTotalEventCountWithProjectID:projectID] == 2, @"2 total event after add");
+    XCTAssertTrue([store getPendingEventCountWithProjectID:projectID] == 2, @"2 pending event after add");
+    XCTAssertTrue([store hasPendingEventsWithProjectID:projectID], @"has pending events!");
 
-    [store resetPendingEvents];
-    XCTAssertTrue([store getTotalEventCount] == 2, @"0 total event after reset");
-    XCTAssertTrue([store getPendingEventCount] == 0, @"2 pending event after reset");
-    XCTAssertFalse([store hasPendingEvents], @"has NO pending events!");
+    [store resetPendingEventsWithProjectID:projectID];
+    XCTAssertTrue([store getTotalEventCountWithProjectID:projectID] == 2, @"0 total event after reset");
+    XCTAssertTrue([store getPendingEventCountWithProjectID:projectID] == 0, @"2 pending event after reset");
+    XCTAssertFalse([store hasPendingEventsWithProjectID:projectID], @"has NO pending events!");
 
     // Again for good measure
-    [store addEvent:[@"I AM AN EVENT" dataUsingEncoding:NSUTF8StringEncoding] collection: @"foo"];
-    [store addEvent:[@"I AM AN EVENT ALSO" dataUsingEncoding:NSUTF8StringEncoding] collection: @"foo"];
+    [store addEvent:[@"I AM AN EVENT" dataUsingEncoding:NSUTF8StringEncoding] collection:@"foo" projectID:projectID];
+    [store addEvent:[@"I AM AN EVENT ALSO" dataUsingEncoding:NSUTF8StringEncoding] collection:@"foo" projectID:projectID];
 
-    [store getEventsWithMaxAttempts:3];
+    [store getEventsWithMaxAttempts:3 andProjectID:projectID];
 
-    [store resetPendingEvents];
-    XCTAssertTrue([store getTotalEventCount] == 4, @"0 total event after add");
-    XCTAssertFalse([store hasPendingEvents], @"No pending events now!");
+    [store resetPendingEventsWithProjectID:projectID];
+    XCTAssertTrue([store getTotalEventCountWithProjectID:projectID] == 4, @"0 total event after add");
+    XCTAssertFalse([store hasPendingEventsWithProjectID:projectID], @"No pending events now!");
 }
 
 - (void)testDeleteFromOffset{
     KIOEventStore *store = [[KIOEventStore alloc] init];
-    store.projectId = @"1234";
-    [store addEvent:[@"I AM AN EVENT" dataUsingEncoding:NSUTF8StringEncoding] collection: @"foo"];
-    [store addEvent:[@"I AM AN EVENT ALSO" dataUsingEncoding:NSUTF8StringEncoding] collection: @"foo"];
-    [store addEvent:[@"I AM AN BUT ANOTHER EVENT ALSO" dataUsingEncoding:NSUTF8StringEncoding] collection: @"foo"];
+    [store addEvent:[@"I AM AN EVENT" dataUsingEncoding:NSUTF8StringEncoding] collection:@"foo" projectID:projectID];
+    [store addEvent:[@"I AM AN EVENT ALSO" dataUsingEncoding:NSUTF8StringEncoding] collection:@"foo" projectID:projectID];
+    [store addEvent:[@"I AM AN BUT ANOTHER EVENT ALSO" dataUsingEncoding:NSUTF8StringEncoding] collection:@"foo" projectID:projectID];
 
     [store deleteEventsFromOffset:@2];
-    XCTAssertTrue([store getTotalEventCount] == 2, @"2 total events after deleteEventsFromOffset");
+    XCTAssertTrue([store getTotalEventCountWithProjectID:projectID] == 2, @"2 total events after deleteEventsFromOffset");
 }
 
 - (void)testClosedDB{
     KIOEventStore *store = [[KIOEventStore alloc] init];
-    store.projectId = @"1234";
     [store closeDB];
 
     // Verify that these methods all behave with a closed database.
-    XCTAssertFalse([store hasPendingEvents], @"no pending if closed");
-    [store resetPendingEvents]; // This shouldn't crash. :P
-    [store purgePendingEvents]; // This shouldn't crash. :P
+    XCTAssertFalse([store hasPendingEventsWithProjectID:projectID], @"no pending if closed");
+    [store resetPendingEventsWithProjectID:projectID]; // This shouldn't crash. :P
+    [store purgePendingEventsWithProjectID:projectID]; // This shouldn't crash. :P
 }
 
 - (NSString *)databaseFile {

--- a/KeenClientTests/KIOQueryTests.m
+++ b/KeenClientTests/KIOQueryTests.m
@@ -49,7 +49,7 @@
 
 //- (void)testAdd{
 //    KIOEventStore *store = [[KIOEventStore alloc] init];
-//    store.projectId = @"1234";
+//    store.projectID = @"1234";
 //    [store addEvent:[@"I AM AN EVENT" dataUsingEncoding:NSUTF8StringEncoding] collection: @"foo"];
 //    XCTAssertTrue([store getTotalEventCount] == 1, @"1 total event after add");
 //    XCTAssertTrue([store getPendingEventCount] == 0, @"0 pending events after add");

--- a/KeenClientTests/KeenClientTests.m
+++ b/KeenClientTests/KeenClientTests.m
@@ -18,7 +18,7 @@
 @interface KeenClient (testability)
 
 // The project ID for this particular client.
-@property (nonatomic, strong) NSString *projectId;
+@property (nonatomic, strong) NSString *projectID;
 @property (nonatomic, strong) NSString *writeKey;
 @property (nonatomic, strong) NSString *readKey;
 
@@ -48,7 +48,7 @@
     [super setUp];
 
     // Set-up code here.
-    [[KeenClient sharedClient] setProjectId:nil];
+    [[KeenClient sharedClient] setProjectID:nil];
     [[KeenClient sharedClient] setWriteKey:nil];
     [[KeenClient sharedClient] setReadKey:nil];
     [KeenClient enableLogging];
@@ -77,24 +77,24 @@
 }
 
 - (void)testInitWithProjectID{
-    KeenClient *client = [[KeenClient alloc] initWithProjectId:@"something" andWriteKey:@"wk" andReadKey:@"rk"];
-    XCTAssertEqualObjects(@"something", client.projectId, @"init with a valid project id should work");
+    KeenClient *client = [[KeenClient alloc] initWithProjectID:@"something" andWriteKey:@"wk" andReadKey:@"rk"];
+    XCTAssertEqualObjects(@"something", client.projectID, @"init with a valid project id should work");
     XCTAssertEqualObjects(@"wk", client.writeKey, @"init with a valid project id should work");
     XCTAssertEqualObjects(@"rk", client.readKey, @"init with a valid project id should work");
     
-    KeenClient *client2 = [[KeenClient alloc] initWithProjectId:@"another" andWriteKey:@"wk2" andReadKey:@"rk2"];
-    XCTAssertEqualObjects(@"another", client2.projectId, @"init with a valid project id should work");
+    KeenClient *client2 = [[KeenClient alloc] initWithProjectID:@"another" andWriteKey:@"wk2" andReadKey:@"rk2"];
+    XCTAssertEqualObjects(@"another", client2.projectID, @"init with a valid project id should work");
     XCTAssertEqualObjects(@"wk2", client2.writeKey, @"init with a valid project id should work");
     XCTAssertEqualObjects(@"rk2", client2.readKey, @"init with a valid project id should work");
     XCTAssertTrue(client != client2, @"Another init should return a separate instance");
     
-    client = [[KeenClient alloc] initWithProjectId:nil andWriteKey:@"wk" andReadKey:@"rk"];
+    client = [[KeenClient alloc] initWithProjectID:nil andWriteKey:@"wk" andReadKey:@"rk"];
     XCTAssertNil(client, @"init with a nil project ID should return nil");
 }
 
 - (void)testInstanceClient {
     KeenClient *client = [[KeenClient alloc] init];
-    XCTAssertNil(client.projectId, @"a client's project id should be nil at first");
+    XCTAssertNil(client.projectID, @"a client's project id should be nil at first");
     XCTAssertNil(client.writeKey, @"a client's write key should be nil at first");
     XCTAssertNil(client.readKey, @"a client's read key should be nil at first");
 
@@ -102,24 +102,24 @@
     XCTAssertTrue(client != client2, @"Another init should return a separate instance");
 }
 
-- (void)testSharedClientWithProjectId{
-    KeenClient *client = [KeenClient sharedClientWithProjectId:@"id" andWriteKey:@"wk" andReadKey:@"rk"];
-    XCTAssertEqual(@"id", client.projectId, @"sharedClientWithProjectId with a non-nil project id should work.");
+- (void)testSharedClientWithProjectID{
+    KeenClient *client = [KeenClient sharedClientWithProjectID:@"id" andWriteKey:@"wk" andReadKey:@"rk"];
+    XCTAssertEqual(@"id", client.projectID, @"sharedClientWithProjectID with a non-nil project id should work.");
     XCTAssertEqualObjects(@"wk", client.writeKey, @"init with a valid project id should work");
     XCTAssertEqualObjects(@"rk", client.readKey, @"init with a valid project id should work");
     
-    KeenClient *client2 = [KeenClient sharedClientWithProjectId:@"other" andWriteKey:@"wk2" andReadKey:@"rk2"];
+    KeenClient *client2 = [KeenClient sharedClientWithProjectID:@"other" andWriteKey:@"wk2" andReadKey:@"rk2"];
     XCTAssertEqualObjects(client, client2, @"sharedClient should return the same instance");
     XCTAssertEqualObjects(@"wk2", client2.writeKey, @"sharedClient with a valid project id should work");
     XCTAssertEqualObjects(@"rk2", client2.readKey, @"sharedClient with a valid project id should work");
     
-    client = [KeenClient sharedClientWithProjectId:nil andWriteKey:@"wk" andReadKey:@"rk"];
+    client = [KeenClient sharedClientWithProjectID:nil andWriteKey:@"wk" andReadKey:@"rk"];
     XCTAssertNil(client, @"sharedClient with an invalid project id should return nil");
 }
 
 - (void)testSharedClient {
     KeenClient *client = [KeenClient sharedClient];
-    XCTAssertNil(client.projectId, @"a client's project id should be nil at first");
+    XCTAssertNil(client.projectID, @"a client's project id should be nil at first");
     XCTAssertNil(client.writeKey, @"a client's write key should be nil at first");
     XCTAssertNil(client.readKey, @"a client's read key should be nil at first");
     
@@ -128,8 +128,8 @@
 }
 
 - (void)testAddEvent {
-    KeenClient *client = [KeenClient sharedClientWithProjectId:@"id" andWriteKey:@"wk" andReadKey:@"rk"];
-    KeenClient *clientI = [[KeenClient alloc] initWithProjectId:@"id" andWriteKey:@"wk" andReadKey:@"rk"];
+    KeenClient *client = [KeenClient sharedClientWithProjectID:@"id" andWriteKey:@"wk" andReadKey:@"rk"];
+    KeenClient *clientI = [[KeenClient alloc] initWithProjectID:@"id" andWriteKey:@"wk" andReadKey:@"rk"];
     
     // nil dict should should do nothing
     NSError *error = nil;
@@ -202,8 +202,8 @@
 }
 
 - (void)testAddEventNoWriteKey {
-    KeenClient *client = [KeenClient sharedClientWithProjectId:@"id" andWriteKey:nil andReadKey:nil];
-    KeenClient *clientI = [[KeenClient alloc] initWithProjectId:@"id" andWriteKey:nil andReadKey:nil];
+    KeenClient *client = [KeenClient sharedClientWithProjectID:@"id" andWriteKey:nil andReadKey:nil];
+    KeenClient *clientI = [[KeenClient alloc] initWithProjectID:@"id" andWriteKey:nil andReadKey:nil];
     
     NSArray *keys = [NSArray arrayWithObjects:@"a", @"b", @"c", nil];
     NSArray *values = [NSArray arrayWithObjects:@"apple", @"bapple", [NSNull null], nil];
@@ -213,8 +213,8 @@
 }
 
 - (void)testEventWithTimestamp {
-    KeenClient *client = [KeenClient sharedClientWithProjectId:@"id" andWriteKey:@"wk" andReadKey:@"rk"];
-    KeenClient *clientI = [[KeenClient alloc] initWithProjectId:@"id" andWriteKey:@"wk" andReadKey:@"rk"];
+    KeenClient *client = [KeenClient sharedClientWithProjectID:@"id" andWriteKey:@"wk" andReadKey:@"rk"];
+    KeenClient *clientI = [[KeenClient alloc] initWithProjectID:@"id" andWriteKey:@"wk" andReadKey:@"rk"];
 
     NSDate *date = [NSDate date];
     KeenProperties *keenProperties = [[KeenProperties alloc] init];
@@ -222,7 +222,7 @@
     [client addEvent:@{@"a": @"b"} withKeenProperties:keenProperties toEventCollection:@"foo" error:nil];
     [clientI addEvent:@{@"a": @"b"} withKeenProperties:keenProperties toEventCollection:@"foo" error:nil];
 
-    NSDictionary *eventsForCollection = [[[KeenClient getEventStore] getEventsWithMaxAttempts:3 andProjectID:client.projectId] objectForKey:@"foo"];
+    NSDictionary *eventsForCollection = [[[KeenClient getEventStore] getEventsWithMaxAttempts:3 andProjectID:client.projectID] objectForKey:@"foo"];
     // Grab the first event we get back
     NSData *eventData = [eventsForCollection objectForKey:[[eventsForCollection allKeys] objectAtIndex:0]];
     NSError *error = nil;
@@ -238,8 +238,8 @@
 }
 
 - (void)testEventWithLocation {
-    KeenClient *client = [KeenClient sharedClientWithProjectId:@"id" andWriteKey:@"wk" andReadKey:@"rk"];
-    KeenClient *clientI = [[KeenClient alloc] initWithProjectId:@"id" andWriteKey:@"wk" andReadKey:@"rk"];
+    KeenClient *client = [KeenClient sharedClientWithProjectID:@"id" andWriteKey:@"wk" andReadKey:@"rk"];
+    KeenClient *clientI = [[KeenClient alloc] initWithProjectID:@"id" andWriteKey:@"wk" andReadKey:@"rk"];
 
     KeenProperties *keenProperties = [[KeenProperties alloc] init];
     CLLocation *location = [[CLLocation alloc] initWithLatitude:37.73 longitude:-122.47];
@@ -247,7 +247,7 @@
     [client addEvent:@{@"a": @"b"} withKeenProperties:keenProperties toEventCollection:@"foo" error:nil];
     [clientI addEvent:@{@"a": @"b"} withKeenProperties:keenProperties toEventCollection:@"foo" error:nil];
 
-    NSDictionary *eventsForCollection = [[[KeenClient getEventStore] getEventsWithMaxAttempts:3 andProjectID:client.projectId] objectForKey:@"foo"];
+    NSDictionary *eventsForCollection = [[[KeenClient getEventStore] getEventsWithMaxAttempts:3 andProjectID:client.projectID] objectForKey:@"foo"];
     // Grab the first event we get back
     NSData *eventData = [eventsForCollection objectForKey:[[eventsForCollection allKeys] objectAtIndex:0]];
     NSError *error = nil;
@@ -262,15 +262,15 @@
 }
 
 - (void)testEventWithDictionary {
-    KeenClient *client = [KeenClient sharedClientWithProjectId:@"id" andWriteKey:@"wk" andReadKey:@"rk"];
-    KeenClient *clientI = [[KeenClient alloc] initWithProjectId:@"id" andWriteKey:@"wk" andReadKey:@"rk"];
+    KeenClient *client = [KeenClient sharedClientWithProjectID:@"id" andWriteKey:@"wk" andReadKey:@"rk"];
+    KeenClient *clientI = [[KeenClient alloc] initWithProjectID:@"id" andWriteKey:@"wk" andReadKey:@"rk"];
 
     NSString* json = @"{\"test_str_array\":[\"val1\",\"val2\",\"val3\"]}";
     NSDictionary* eventDictionary = [NSJSONSerialization JSONObjectWithData:[json dataUsingEncoding:NSUTF8StringEncoding] options:0 error:nil];
 
     [client addEvent:eventDictionary toEventCollection:@"foo" error:nil];
     [clientI addEvent:eventDictionary toEventCollection:@"foo" error:nil];
-    NSDictionary *eventsForCollection = [[[KeenClient getEventStore] getEventsWithMaxAttempts:3 andProjectID:client.projectId] objectForKey:@"foo"];
+    NSDictionary *eventsForCollection = [[[KeenClient getEventStore] getEventsWithMaxAttempts:3 andProjectID:client.projectID] objectForKey:@"foo"];
     // Grab the first event we get back
     NSData *eventData = [eventsForCollection objectForKey:[[eventsForCollection allKeys] objectAtIndex:0]];
     NSError *error = nil;
@@ -285,8 +285,8 @@
 
 - (void)testGeoLocation {
     // set up a client with a location
-    KeenClient *client = [KeenClient sharedClientWithProjectId:@"id" andWriteKey:@"wk" andReadKey:@"rk"];
-    KeenClient *clientI = [[KeenClient alloc] initWithProjectId:@"id" andWriteKey:@"wk" andReadKey:@"rk"];
+    KeenClient *client = [KeenClient sharedClientWithProjectID:@"id" andWriteKey:@"wk" andReadKey:@"rk"];
+    KeenClient *clientI = [[KeenClient alloc] initWithProjectID:@"id" andWriteKey:@"wk" andReadKey:@"rk"];
     
     CLLocation *location = [[CLLocation alloc] initWithLatitude:37.73 longitude:-122.47];
     client.currentLocation = location;
@@ -294,7 +294,7 @@
     [client addEvent:@{@"a": @"b"} toEventCollection:@"foo" error:nil];
     [clientI addEvent:@{@"a": @"b"} toEventCollection:@"foo" error:nil];
     // now get the stored event
-    NSDictionary *eventsForCollection = [[[KeenClient getEventStore] getEventsWithMaxAttempts:3 andProjectID:client.projectId] objectForKey:@"foo"];
+    NSDictionary *eventsForCollection = [[[KeenClient getEventStore] getEventsWithMaxAttempts:3 andProjectID:client.projectID] objectForKey:@"foo"];
     // Grab the first event we get back
     NSData *eventData = [eventsForCollection objectForKey:[[eventsForCollection allKeys] objectAtIndex:0]];
     NSError *error = nil;
@@ -310,8 +310,8 @@
 
 - (void)testGeoLocationDisabled {
     // now try the same thing but disable geo location
-    KeenClient *client = [KeenClient sharedClientWithProjectId:@"id" andWriteKey:@"wk" andReadKey:@"rk"];
-    KeenClient *clientI = [[KeenClient alloc] initWithProjectId:@"id" andWriteKey:@"wk" andReadKey:@"rk"];
+    KeenClient *client = [KeenClient sharedClientWithProjectID:@"id" andWriteKey:@"wk" andReadKey:@"rk"];
+    KeenClient *clientI = [[KeenClient alloc] initWithProjectID:@"id" andWriteKey:@"wk" andReadKey:@"rk"];
     
     [KeenClient disableGeoLocation];
     // add an event
@@ -320,7 +320,7 @@
     // now get the stored event
 
     // Grab the first event we get back
-    NSDictionary *eventsForCollection = [[[KeenClient getEventStore] getEventsWithMaxAttempts:3 andProjectID:client.projectId] objectForKey:@"bar"];
+    NSDictionary *eventsForCollection = [[[KeenClient getEventStore] getEventsWithMaxAttempts:3 andProjectID:client.projectID] objectForKey:@"bar"];
     // Grab the first event we get back
     NSData *eventData = [eventsForCollection objectForKey:[[eventsForCollection allKeys] objectAtIndex:0]];
     NSError *error = nil;
@@ -333,8 +333,8 @@
 }
 
 - (void)testEventWithNonDictionaryKeen {
-    KeenClient *client = [KeenClient sharedClientWithProjectId:@"id" andWriteKey:@"wk" andReadKey:@"rk"];
-    KeenClient *clientI = [[KeenClient alloc] initWithProjectId:@"id" andWriteKey:@"wk" andReadKey:@"rk"];
+    KeenClient *client = [KeenClient sharedClientWithProjectID:@"id" andWriteKey:@"wk" andReadKey:@"rk"];
+    KeenClient *clientI = [[KeenClient alloc] initWithProjectID:@"id" andWriteKey:@"wk" andReadKey:@"rk"];
     
     NSDictionary *theEvent = @{@"keen": @"abc"};
     NSError *error = nil;
@@ -344,8 +344,8 @@
 }
 
 - (void)testBasicAddon {
-    KeenClient *client = [KeenClient sharedClientWithProjectId:@"id" andWriteKey:@"wk" andReadKey:@"rk"];
-    KeenClient *clientI = [[KeenClient alloc] initWithProjectId:@"id" andWriteKey:@"wk" andReadKey:@"rk"];
+    KeenClient *client = [KeenClient sharedClientWithProjectID:@"id" andWriteKey:@"wk" andReadKey:@"rk"];
+    KeenClient *clientI = [[KeenClient alloc] initWithProjectID:@"id" andWriteKey:@"wk" andReadKey:@"rk"];
     
     NSDictionary *theEvent = @{
                                @"keen":@{
@@ -367,7 +367,7 @@
     XCTAssertNil(error, @"event should add");
     
     // Grab the first event we get back
-    NSDictionary *eventsForCollection = [[[KeenClient getEventStore] getEventsWithMaxAttempts:3 andProjectID:client.projectId] objectForKey:@"foo"];
+    NSDictionary *eventsForCollection = [[[KeenClient getEventStore] getEventsWithMaxAttempts:3 andProjectID:client.projectID] objectForKey:@"foo"];
     // Grab the first event we get back
     NSData *eventData = [eventsForCollection objectForKey:[[eventsForCollection allKeys] objectAtIndex:0]];
     NSDictionary *deserializedDict = [NSJSONSerialization JSONObjectWithData:eventData
@@ -413,7 +413,7 @@
     }
     
     // set up the partial mock
-    KeenClient *client = [KeenClient sharedClientWithProjectId:@"id" andWriteKey:@"wk" andReadKey:@"rk"];
+    KeenClient *client = [KeenClient sharedClientWithProjectID:@"id" andWriteKey:@"wk" andReadKey:@"rk"];
     client.isRunningTests = YES;
     id mock = [OCMockObject partialMockForObject:client];
     
@@ -441,7 +441,7 @@
     }
     
     // set up the partial mock
-    KeenClient *client = [[KeenClient alloc] initWithProjectId:@"id" andWriteKey:@"wk" andReadKey:@"rk"];
+    KeenClient *client = [[KeenClient alloc] initWithProjectID:@"id" andWriteKey:@"wk" andReadKey:@"rk"];
     client.isRunningTests = YES;
     id mock = [OCMockObject partialMockForObject:client];
     
@@ -465,7 +465,7 @@
 
 - (id)queryMockTestHelper:(id)responseData andStatusCode:(NSInteger)code {
     // set up the partial mock
-    KeenClient *client = [[KeenClient alloc] initWithProjectId:@"id" andWriteKey:@"wk" andReadKey:@"rk"];
+    KeenClient *client = [[KeenClient alloc] initWithProjectID:@"id" andWriteKey:@"wk" andReadKey:@"rk"];
     client.isRunningTests = YES;
     id mock = [OCMockObject partialMockForObject:client];
     
@@ -485,7 +485,7 @@
 
 - (id)queryMultiAnalysisMockTestHelper:(id)responseData andStatusCode:(NSInteger)code {
     // set up the partial mock
-    KeenClient *client = [[KeenClient alloc] initWithProjectId:@"id" andWriteKey:@"wk" andReadKey:@"rk"];
+    KeenClient *client = [[KeenClient alloc] initWithProjectID:@"id" andWriteKey:@"wk" andReadKey:@"rk"];
     client.isRunningTests = YES;
     id mock = [OCMockObject partialMockForObject:client];
     
@@ -518,7 +518,7 @@
     
     [mock uploadWithFinishedBlock:nil];
     
-    XCTAssertTrue([[KeenClient getEventStore] getTotalEventCountWithProjectID:[mock projectId]] == 0, @"Upload method should return with message Request data is empty.");
+    XCTAssertTrue([[KeenClient getEventStore] getTotalEventCountWithProjectID:[mock projectID]] == 0, @"Upload method should return with message Request data is empty.");
 }
 
 - (void)testUploadSuccess {
@@ -527,7 +527,7 @@
     [self addSimpleEventAndUploadWithMock:mock];
     
     // make sure the event was deleted from the store
-    XCTAssertTrue([[KeenClient getEventStore] getTotalEventCountWithProjectID:[mock projectId]] == 0, @"There should be no files after a successful upload.");
+    XCTAssertTrue([[KeenClient getEventStore] getTotalEventCountWithProjectID:[mock projectID]] == 0, @"There should be no files after a successful upload.");
 }
 
 - (void)testUploadSuccessInstanceClient {
@@ -536,7 +536,7 @@
     [self addSimpleEventAndUploadWithMock:mock];
     
     // make sure the event was deleted from the store
-    XCTAssertTrue([[KeenClient getEventStore] getTotalEventCountWithProjectID:[mock projectId]] == 0, @"There should be no files after a successful upload.");
+    XCTAssertTrue([[KeenClient getEventStore] getTotalEventCountWithProjectID:[mock projectID]] == 0, @"There should be no files after a successful upload.");
 }
 
 - (void)testUploadSuccessCreated {
@@ -545,7 +545,7 @@
     [self addSimpleEventAndUploadWithMock:mock];
     
     // make sure the event was deleted from the store
-    XCTAssertTrue([[KeenClient getEventStore] getTotalEventCountWithProjectID:[mock projectId]] == 0, @"There should be no files after a successful upload.");
+    XCTAssertTrue([[KeenClient getEventStore] getTotalEventCountWithProjectID:[mock projectID]] == 0, @"There should be no files after a successful upload.");
 }
 
 - (void)testUploadSuccessCreatedInstanceClient {
@@ -554,7 +554,7 @@
     [self addSimpleEventAndUploadWithMock:mock];
     
     // make sure the event was deleted from the store
-    XCTAssertTrue([[KeenClient getEventStore] getTotalEventCountWithProjectID:[mock projectId]] == 0, @"There should be no files after a successful upload.");
+    XCTAssertTrue([[KeenClient getEventStore] getTotalEventCountWithProjectID:[mock projectID]] == 0, @"There should be no files after a successful upload.");
 }
 
 - (void)testUploadFailedServerDown {
@@ -563,16 +563,16 @@
     [self addSimpleEventAndUploadWithMock:mock];
 
     // make sure the file wasn't deleted from the store
-    XCTAssertTrue([[KeenClient getEventStore] getTotalEventCountWithProjectID:[mock projectId]] == 1, @"There should be one files after a successful upload.");
+    XCTAssertTrue([[KeenClient getEventStore] getTotalEventCountWithProjectID:[mock projectID]] == 1, @"There should be one files after a successful upload.");
 }
 
 - (void)testUploadFailedServerDownInstanceClient {
-    id mock = [self uploadTestHelperWithDataInstanceClient:[mock projectId] andStatusCode:HTTPCode500InternalServerError];
+    id mock = [self uploadTestHelperWithDataInstanceClient:[mock projectID] andStatusCode:HTTPCode500InternalServerError];
     
     [self addSimpleEventAndUploadWithMock:mock];
     
     // make sure the file wasn't deleted from the store
-    XCTAssertTrue([[KeenClient getEventStore] getTotalEventCountWithProjectID:[mock projectId]] == 1, @"There should be one files after a successful upload.");
+    XCTAssertTrue([[KeenClient getEventStore] getTotalEventCountWithProjectID:[mock projectID]] == 1, @"There should be one files after a successful upload.");
 }
 
 - (void)testUploadFailedServerDownNonJsonResponse {
@@ -581,7 +581,7 @@
     [self addSimpleEventAndUploadWithMock:mock];
     
     // make sure the file wasn't deleted locally
-    XCTAssertTrue([[KeenClient getEventStore] getTotalEventCountWithProjectID:[mock projectId]] == 1, @"There should be one files after a successful upload.");
+    XCTAssertTrue([[KeenClient getEventStore] getTotalEventCountWithProjectID:[mock projectID]] == 1, @"There should be one files after a successful upload.");
 }
 
 - (void)testUploadFailedServerDownNonJsonResponseInstanceClient {
@@ -590,7 +590,7 @@
     [self addSimpleEventAndUploadWithMock:mock];
     
     // make sure the file wasn't deleted locally
-    XCTAssertTrue([[KeenClient getEventStore] getTotalEventCountWithProjectID:[mock projectId]] == 1, @"There should be one files after a successful upload.");
+    XCTAssertTrue([[KeenClient getEventStore] getTotalEventCountWithProjectID:[mock projectID]] == 1, @"There should be one files after a successful upload.");
 }
 
 
@@ -604,7 +604,7 @@
     [mock uploadWithFinishedBlock:nil];
 
     // make sure the file wasn't deleted from the store
-    XCTAssertTrue([[KeenClient getEventStore] getTotalEventCountWithProjectID:[mock projectId]] == 1, @"There should be one file after an unsuccessful attempts.");
+    XCTAssertTrue([[KeenClient getEventStore] getTotalEventCountWithProjectID:[mock projectID]] == 1, @"There should be one file after an unsuccessful attempts.");
 
 
     // add another event
@@ -612,19 +612,19 @@
     [mock uploadWithFinishedBlock:nil];
 
     // make sure both filef weren't deleted from the store
-    XCTAssertTrue([[KeenClient getEventStore] getTotalEventCountWithProjectID:[mock projectId]] == 2, @"There should be two files after 2 unsuccessful attempts.");
+    XCTAssertTrue([[KeenClient getEventStore] getTotalEventCountWithProjectID:[mock projectID]] == 2, @"There should be two files after 2 unsuccessful attempts.");
 
 
     [mock uploadWithFinishedBlock:nil];
 
     // make sure the first file was deleted from the store, but the second one remains
-    XCTAssertTrue([[[KeenClient getEventStore] getEventsWithMaxAttempts:3 andProjectID:[mock projectId]] allKeys].count == 1, @"There should be one files after 3 unsuccessful attempts.");
+    XCTAssertTrue([[[KeenClient getEventStore] getEventsWithMaxAttempts:3 andProjectID:[mock projectID]] allKeys].count == 1, @"There should be one files after 3 unsuccessful attempts.");
 
 
     [mock uploadWithFinishedBlock:nil];
 
     // make sure both files were delete from the store
-    XCTAssertTrue([[[KeenClient getEventStore] getEventsWithMaxAttempts:3 andProjectID:[mock projectId]] allKeys].count == 0, @"There should be no files after 3 unsuccessfull attempts.");
+    XCTAssertTrue([[[KeenClient getEventStore] getEventsWithMaxAttempts:3 andProjectID:[mock projectID]] allKeys].count == 0, @"There should be no files after 3 unsuccessfull attempts.");
 }
 
 - (void)testIncrementEvenOnNoResponse {
@@ -638,21 +638,21 @@
     [mock uploadWithFinishedBlock:nil];
 
     // make sure the file wasn't deleted from the store
-    XCTAssertTrue([[KeenClient getEventStore] getTotalEventCountWithProjectID:[mock projectId]] == 1, @"There should be one event after an unsuccessful attempt.");
+    XCTAssertTrue([[KeenClient getEventStore] getTotalEventCountWithProjectID:[mock projectID]] == 1, @"There should be one event after an unsuccessful attempt.");
 
 
     // add another event
     [mock uploadWithFinishedBlock:nil];
 
     // make sure both filef weren't deleted from the store
-    XCTAssertTrue([[KeenClient getEventStore] getTotalEventCountWithProjectID:[mock projectId]] == 1, @"There should be one event after 2 unsuccessful attempts.");
+    XCTAssertTrue([[KeenClient getEventStore] getTotalEventCountWithProjectID:[mock projectID]] == 1, @"There should be one event after 2 unsuccessful attempts.");
 
 
     [mock uploadWithFinishedBlock:nil];
 
     // make sure the event was incremented
-    XCTAssertTrue([[[KeenClient getEventStore] getEventsWithMaxAttempts:3 andProjectID:[mock projectId]] allKeys].count == 0, @"There should be no events with less than 3 unsuccessful attempts.");
-    XCTAssertTrue([[[KeenClient getEventStore] getEventsWithMaxAttempts:4 andProjectID:[mock projectId]] allKeys].count == 1, @"There should be one event with less than 4 unsuccessful attempts.");
+    XCTAssertTrue([[[KeenClient getEventStore] getEventsWithMaxAttempts:3 andProjectID:[mock projectID]] allKeys].count == 0, @"There should be no events with less than 3 unsuccessful attempts.");
+    XCTAssertTrue([[[KeenClient getEventStore] getEventsWithMaxAttempts:4 andProjectID:[mock projectID]] allKeys].count == 1, @"There should be one event with less than 4 unsuccessful attempts.");
 }
 
 - (void)testUploadFailedBadRequest {
@@ -687,7 +687,7 @@
     [self addSimpleEventAndUploadWithMock:mock];
     
     // make sure the file wasn't deleted locally
-    XCTAssertTrue([[KeenClient getEventStore] getTotalEventCountWithProjectID:[mock projectId]] == 1, @"An upload that results in an unexpected error should not delete the event.");
+    XCTAssertTrue([[KeenClient getEventStore] getTotalEventCountWithProjectID:[mock projectID]] == 1, @"An upload that results in an unexpected error should not delete the event.");
 }
 
 - (void)testUploadFailedBadRequestUnknownErrorInstanceClient {
@@ -696,7 +696,7 @@
     [self addSimpleEventAndUploadWithMock:mock];
 
     // make sure the file wasn't deleted locally
-    XCTAssertTrue([[KeenClient getEventStore] getTotalEventCountWithProjectID:[mock projectId]] == 1, @"An upload that results in an unexpected error should not delete the event.");
+    XCTAssertTrue([[KeenClient getEventStore] getTotalEventCountWithProjectID:[mock projectID]] == 1, @"An upload that results in an unexpected error should not delete the event.");
 }
 
 - (void)testUploadFailedRedirectionStatus {
@@ -705,7 +705,7 @@
     [self addSimpleEventAndUploadWithMock:mock];
     
     // make sure the file wasn't deleted locally
-    XCTAssertTrue([[KeenClient getEventStore] getTotalEventCountWithProjectID:[mock projectId]] == 1, @"An upload that results in an unexpected error should not delete the event.");
+    XCTAssertTrue([[KeenClient getEventStore] getTotalEventCountWithProjectID:[mock projectID]] == 1, @"An upload that results in an unexpected error should not delete the event.");
 }
 
 - (void)testUploadFailedRedirectionStatusInstanceClient {
@@ -714,7 +714,7 @@
     [self addSimpleEventAndUploadWithMock:mock];
     
     // make sure the file wasn't deleted locally
-    XCTAssertTrue([[KeenClient getEventStore] getTotalEventCountWithProjectID:[mock projectId]] == 1, @"An upload that results in an unexpected error should not delete the event.");
+    XCTAssertTrue([[KeenClient getEventStore] getTotalEventCountWithProjectID:[mock projectID]] == 1, @"An upload that results in an unexpected error should not delete the event.");
 }
 
 - (void)testUploadSkippedNoNetwork {
@@ -724,7 +724,7 @@
     [self addSimpleEventAndUploadWithMock:mock];
 
     // make sure the file wasn't deleted locally
-    XCTAssertTrue([[KeenClient getEventStore] getTotalEventCountWithProjectID:[mock projectId]] == 1, @"An upload with no network should not delete the event.");
+    XCTAssertTrue([[KeenClient getEventStore] getTotalEventCountWithProjectID:[mock projectID]] == 1, @"An upload with no network should not delete the event.");
 }
 
 - (void)testUploadMultipleEventsSameCollectionSuccess {
@@ -836,7 +836,7 @@
     [mock uploadWithFinishedBlock:nil];
 
     // make sure the file were deleted locally
-    XCTAssertTrue([[KeenClient getEventStore] getTotalEventCountWithProjectID:[mock projectId]] == 0,  @"There should be no events after a successful upload.");
+    XCTAssertTrue([[KeenClient getEventStore] getTotalEventCountWithProjectID:[mock projectID]] == 0,  @"There should be no events after a successful upload.");
 }
 
 - (void)testUploadMultipleEventsSameCollectionOneFailsInstanceClient {
@@ -858,7 +858,7 @@
     [mock uploadWithFinishedBlock:nil];
     
     // make sure the file were deleted locally
-    XCTAssertTrue([[KeenClient getEventStore] getTotalEventCountWithProjectID:[mock projectId]] == 0,  @"There should be no events after a successful upload.");
+    XCTAssertTrue([[KeenClient getEventStore] getTotalEventCountWithProjectID:[mock projectID]] == 0,  @"There should be no events after a successful upload.");
 }
 
 - (void)testUploadMultipleEventsDifferentCollectionsOneFails {
@@ -881,7 +881,7 @@
     [mock uploadWithFinishedBlock:nil];
 
     // make sure the files were deleted locally
-    XCTAssertTrue([[KeenClient getEventStore] getTotalEventCountWithProjectID:[mock projectId]] == 0,  @"There should be no events after a successful upload.");
+    XCTAssertTrue([[KeenClient getEventStore] getTotalEventCountWithProjectID:[mock projectID]] == 0,  @"There should be no events after a successful upload.");
 }
 
 - (void)testUploadMultipleEventsDifferentCollectionsOneFailsInstanceClient {
@@ -904,7 +904,7 @@
     [mock uploadWithFinishedBlock:nil];
     
     // make sure the files were deleted locally
-    XCTAssertTrue([[KeenClient getEventStore] getTotalEventCountWithProjectID:[mock projectId]] == 0,  @"There should be no events after a successful upload.");
+    XCTAssertTrue([[KeenClient getEventStore] getTotalEventCountWithProjectID:[mock projectID]] == 0,  @"There should be no events after a successful upload.");
 }
 
 - (void)testUploadMultipleEventsDifferentCollectionsOneFailsForServerReason {
@@ -927,7 +927,7 @@
     [mock uploadWithFinishedBlock:nil];
 
     // make sure the files were deleted locally
-    XCTAssertTrue([[KeenClient getEventStore] getTotalEventCountWithProjectID:[mock projectId]] == 1,  @"There should be 1 events after a partial upload.");
+    XCTAssertTrue([[KeenClient getEventStore] getTotalEventCountWithProjectID:[mock projectID]] == 1,  @"There should be 1 events after a partial upload.");
 }
 
 - (void)testUploadMultipleEventsDifferentCollectionsOneFailsForServerReasonInstanceClient {
@@ -950,41 +950,41 @@
     [mock uploadWithFinishedBlock:nil];
     
     // make sure the files were deleted locally
-    XCTAssertTrue([[KeenClient getEventStore] getTotalEventCountWithProjectID:[mock projectId]] == 1,  @"There should be 1 events after a partial upload.");
+    XCTAssertTrue([[KeenClient getEventStore] getTotalEventCountWithProjectID:[mock projectID]] == 1,  @"There should be 1 events after a partial upload.");
 }
 
 - (void)testTooManyEventsCached {
-    KeenClient *client = [KeenClient sharedClientWithProjectId:@"id" andWriteKey:@"wk" andReadKey:@"rk"];
+    KeenClient *client = [KeenClient sharedClientWithProjectID:@"id" andWriteKey:@"wk" andReadKey:@"rk"];
     client.isRunningTests = YES;
     NSDictionary *event = [NSDictionary dictionaryWithObjectsAndKeys:@"bar", @"foo", nil];
     // create 5 events
     for (int i=0; i<5; i++) {
         [client addEvent:event toEventCollection:@"something" error:nil];
     }
-    XCTAssertTrue([[KeenClient getEventStore] getTotalEventCountWithProjectID:client.projectId] == 5,  @"There should be exactly five events.");
+    XCTAssertTrue([[KeenClient getEventStore] getTotalEventCountWithProjectID:client.projectID] == 5,  @"There should be exactly five events.");
     // now do one more, should age out 1 old ones
     [client addEvent:event toEventCollection:@"something" error:nil];
     // so now there should be 4 left (5 - 2 + 1)
-    XCTAssertTrue([[KeenClient getEventStore] getTotalEventCountWithProjectID:client.projectId] == 4, @"There should be exactly five events.");
+    XCTAssertTrue([[KeenClient getEventStore] getTotalEventCountWithProjectID:client.projectID] == 4, @"There should be exactly five events.");
 }
 
 - (void)testTooManyEventsCachedInstanceClient {
-    KeenClient *client = [[KeenClient alloc] initWithProjectId:@"id" andWriteKey:@"wk" andReadKey:@"rk"];
+    KeenClient *client = [[KeenClient alloc] initWithProjectID:@"id" andWriteKey:@"wk" andReadKey:@"rk"];
     client.isRunningTests = YES;
     NSDictionary *event = [NSDictionary dictionaryWithObjectsAndKeys:@"bar", @"foo", nil];
     // create 5 events
     for (int i=0; i<5; i++) {
         [client addEvent:event toEventCollection:@"something" error:nil];
     }
-    XCTAssertTrue([[KeenClient getEventStore] getTotalEventCountWithProjectID:client.projectId] == 5,  @"There should be exactly five events.");
+    XCTAssertTrue([[KeenClient getEventStore] getTotalEventCountWithProjectID:client.projectID] == 5,  @"There should be exactly five events.");
     // now do one more, should age out 1 old ones
     [client addEvent:event toEventCollection:@"something" error:nil];
     // so now there should be 4 left (5 - 2 + 1)
-    XCTAssertTrue([[KeenClient getEventStore] getTotalEventCountWithProjectID:client.projectId] == 4, @"There should be exactly five events.");
+    XCTAssertTrue([[KeenClient getEventStore] getTotalEventCountWithProjectID:client.projectID] == 4, @"There should be exactly five events.");
 }
 
 - (void)testGlobalPropertiesDictionary {
-    KeenClient *client = [KeenClient sharedClientWithProjectId:@"id" andWriteKey:@"wk" andReadKey:@"rk"];
+    KeenClient *client = [KeenClient sharedClientWithProjectID:@"id" andWriteKey:@"wk" andReadKey:@"rk"];
     client.isRunningTests = YES;
     
     NSDictionary * (^RunTest)(NSDictionary*, NSUInteger) = ^(NSDictionary *globalProperties,
@@ -993,7 +993,7 @@
         client.globalPropertiesDictionary = globalProperties;
         NSDictionary *event = @{@"foo": @"bar"};
         [client addEvent:event toEventCollection:eventCollectionName error:nil];
-        NSDictionary *eventsForCollection = [[[KeenClient getEventStore] getEventsWithMaxAttempts:3 andProjectID:client.projectId] objectForKey:eventCollectionName];
+        NSDictionary *eventsForCollection = [[[KeenClient getEventStore] getEventsWithMaxAttempts:3 andProjectID:client.projectID] objectForKey:eventCollectionName];
         // Grab the first event we get back
         NSData *eventData = [eventsForCollection objectForKey:[[eventsForCollection allKeys] objectAtIndex:0]];
         NSError *error = nil;
@@ -1039,7 +1039,7 @@
 }
 
 - (void)testGlobalPropertiesDictionaryInstanceClient {
-    KeenClient *client = [[KeenClient alloc] initWithProjectId:@"id" andWriteKey:@"wk" andReadKey:@"rk"];
+    KeenClient *client = [[KeenClient alloc] initWithProjectID:@"id" andWriteKey:@"wk" andReadKey:@"rk"];
     client.isRunningTests = YES;
     
     NSDictionary * (^RunTest)(NSDictionary*, NSUInteger) = ^(NSDictionary *globalProperties,
@@ -1048,7 +1048,7 @@
         client.globalPropertiesDictionary = globalProperties;
         NSDictionary *event = @{@"foo": @"bar"};
         [client addEvent:event toEventCollection:eventCollectionName error:nil];
-        NSDictionary *eventsForCollection = [[[KeenClient getEventStore] getEventsWithMaxAttempts:3 andProjectID:client.projectId] objectForKey:eventCollectionName];
+        NSDictionary *eventsForCollection = [[[KeenClient getEventStore] getEventsWithMaxAttempts:3 andProjectID:client.projectID] objectForKey:eventCollectionName];
         // Grab the first event we get back
         NSData *eventData = [eventsForCollection objectForKey:[[eventsForCollection allKeys] objectAtIndex:0]];
         NSError *error = nil;
@@ -1094,7 +1094,7 @@
 }
 
 - (void)testGlobalPropertiesBlock {
-    KeenClient *client = [KeenClient sharedClientWithProjectId:@"id" andWriteKey:@"wk" andReadKey:@"rk"];
+    KeenClient *client = [KeenClient sharedClientWithProjectID:@"id" andWriteKey:@"wk" andReadKey:@"rk"];
     client.isRunningTests = YES;
     
     NSDictionary * (^RunTest)(KeenGlobalPropertiesBlock, NSUInteger) = ^(KeenGlobalPropertiesBlock block,
@@ -1104,7 +1104,7 @@
         NSDictionary *event = @{@"foo": @"bar"};
         [client addEvent:event toEventCollection:eventCollectionName error:nil];
 
-        NSDictionary *eventsForCollection = [[[KeenClient getEventStore] getEventsWithMaxAttempts:3 andProjectID:client.projectId] objectForKey:eventCollectionName];
+        NSDictionary *eventsForCollection = [[[KeenClient getEventStore] getEventsWithMaxAttempts:3 andProjectID:client.projectID] objectForKey:eventCollectionName];
         // Grab the first event we get back
         NSData *eventData = [eventsForCollection objectForKey:[[eventsForCollection allKeys] objectAtIndex:0]];
         NSError *error = nil;
@@ -1157,7 +1157,7 @@
 }
 
 - (void)testGlobalPropertiesBlockInstanceClient {
-    KeenClient *client = [[KeenClient alloc] initWithProjectId:@"id" andWriteKey:@"wk" andReadKey:@"rk"];
+    KeenClient *client = [[KeenClient alloc] initWithProjectID:@"id" andWriteKey:@"wk" andReadKey:@"rk"];
     client.isRunningTests = YES;
     
     NSDictionary * (^RunTest)(KeenGlobalPropertiesBlock, NSUInteger) = ^(KeenGlobalPropertiesBlock block,
@@ -1167,7 +1167,7 @@
         NSDictionary *event = @{@"foo": @"bar"};
         [client addEvent:event toEventCollection:eventCollectionName error:nil];
         
-        NSDictionary *eventsForCollection = [[[KeenClient getEventStore] getEventsWithMaxAttempts:3 andProjectID:client.projectId] objectForKey:eventCollectionName];
+        NSDictionary *eventsForCollection = [[[KeenClient getEventStore] getEventsWithMaxAttempts:3 andProjectID:client.projectID] objectForKey:eventCollectionName];
         // Grab the first event we get back
         NSData *eventData = [eventsForCollection objectForKey:[[eventsForCollection allKeys] objectAtIndex:0]];
         NSError *error = nil;
@@ -1220,7 +1220,7 @@
 }
 
 - (void)testGlobalPropertiesTogether {
-    KeenClient *client = [KeenClient sharedClientWithProjectId:@"id" andWriteKey:@"wk" andReadKey:@"rk"];
+    KeenClient *client = [KeenClient sharedClientWithProjectID:@"id" andWriteKey:@"wk" andReadKey:@"rk"];
     client.isRunningTests = YES;
     
     // properties from the block should take precedence over properties from the dictionary
@@ -1231,7 +1231,7 @@
     };
     [client addEvent:@{@"foo": @"bar"} toEventCollection:@"apples" error:nil];
 
-    NSDictionary *eventsForCollection = [[[KeenClient getEventStore] getEventsWithMaxAttempts:3 andProjectID:client.projectId] objectForKey:@"apples"];
+    NSDictionary *eventsForCollection = [[[KeenClient getEventStore] getEventsWithMaxAttempts:3 andProjectID:client.projectID] objectForKey:@"apples"];
     // Grab the first event we get back
     NSData *eventData = [eventsForCollection objectForKey:[[eventsForCollection allKeys] objectAtIndex:0]];
     NSError *error = nil;
@@ -1245,7 +1245,7 @@
 }
 
 - (void)testGlobalPropertiesTogetherInstanceClient {
-    KeenClient *client = [[KeenClient alloc] initWithProjectId:@"id" andWriteKey:@"wk" andReadKey:@"rk"];
+    KeenClient *client = [[KeenClient alloc] initWithProjectID:@"id" andWriteKey:@"wk" andReadKey:@"rk"];
     client.isRunningTests = YES;
     
     // properties from the block should take precedence over properties from the dictionary
@@ -1256,7 +1256,7 @@
     };
     [client addEvent:@{@"foo": @"bar"} toEventCollection:@"apples" error:nil];
     
-    NSDictionary *eventsForCollection = [[[KeenClient getEventStore] getEventsWithMaxAttempts:3 andProjectID:client.projectId] objectForKey:@"apples"];
+    NSDictionary *eventsForCollection = [[[KeenClient getEventStore] getEventsWithMaxAttempts:3 andProjectID:client.projectID] objectForKey:@"apples"];
     // Grab the first event we get back
     NSData *eventData = [eventsForCollection objectForKey:[[eventsForCollection allKeys] objectAtIndex:0]];
     NSError *error = nil;
@@ -1270,7 +1270,7 @@
 }
 
 - (void)testInvalidEventCollection {
-    KeenClient *client = [KeenClient sharedClientWithProjectId:@"id" andWriteKey:@"wk" andReadKey:@"rk"];
+    KeenClient *client = [KeenClient sharedClientWithProjectID:@"id" andWriteKey:@"wk" andReadKey:@"rk"];
     client.isRunningTests = YES;
     
     NSDictionary *event = @{@"a": @"b"};
@@ -1290,7 +1290,7 @@
 }
 
 - (void)testInvalidEventCollectionInstanceClient {
-    KeenClient *client = [[KeenClient alloc] initWithProjectId:@"id" andWriteKey:@"wk" andReadKey:@"rk"];
+    KeenClient *client = [[KeenClient alloc] initWithProjectID:@"id" andWriteKey:@"wk" andReadKey:@"rk"];
     client.isRunningTests = YES;
     
     NSDictionary *event = @{@"a": @"b"};
@@ -1310,7 +1310,7 @@
 }
 
 - (void)testUploadMultipleTimes {
-    KeenClient *client = [KeenClient sharedClientWithProjectId:@"id" andWriteKey:@"wk" andReadKey:@"rk"];
+    KeenClient *client = [KeenClient sharedClientWithProjectID:@"id" andWriteKey:@"wk" andReadKey:@"rk"];
     client.isRunningTests = YES;
     
     [client uploadWithFinishedBlock:nil];
@@ -1319,7 +1319,7 @@
 }
 
 - (void)testUploadMultipleTimesInstanceClient {
-    KeenClient *client = [[KeenClient alloc] initWithProjectId:@"id" andWriteKey:@"wk" andReadKey:@"rk"];
+    KeenClient *client = [[KeenClient alloc] initWithProjectID:@"id" andWriteKey:@"wk" andReadKey:@"rk"];
     client.isRunningTests = YES;
     
     [client uploadWithFinishedBlock:nil];
@@ -1329,7 +1329,7 @@
 
 - (void)testMigrateFSEvents {
 
-    KeenClient *client = [KeenClient sharedClientWithProjectId:@"id" andWriteKey:@"wk" andReadKey:@"rk"];
+    KeenClient *client = [KeenClient sharedClientWithProjectID:@"id" andWriteKey:@"wk" andReadKey:@"rk"];
     client.isRunningTests = YES;
 
     // make sure the directory we want to write the file to exists
@@ -1359,12 +1359,12 @@
     NSDictionary *event3 = @{@"nested": @{@"keen": @"whatever"}};
     [client addEvent:event3 toEventCollection:@"foo" error:nil];
 
-    XCTAssertTrue([[KeenClient getEventStore] getTotalEventCountWithProjectID:client.projectId] == 3,  @"There should be 3 events after an import.");
+    XCTAssertTrue([[KeenClient getEventStore] getTotalEventCountWithProjectID:client.projectID] == 3,  @"There should be 3 events after an import.");
     XCTAssertFalse([manager fileExistsAtPath:[self keenDirectory] isDirectory:true], @"The Keen directory should be gone.");
 }
 
 - (void)testMigrateFSEventsInstanceClient {
-    KeenClient *client = [[KeenClient alloc] initWithProjectId:@"id" andWriteKey:@"wk" andReadKey:@"rk"];
+    KeenClient *client = [[KeenClient alloc] initWithProjectID:@"id" andWriteKey:@"wk" andReadKey:@"rk"];
     client.isRunningTests = YES;
     
     // make sure the directory we want to write the file to exists
@@ -1394,12 +1394,12 @@
     NSDictionary *event3 = @{@"nested": @{@"keen": @"whatever"}};
     [client addEvent:event3 toEventCollection:@"foo" error:nil];
     
-    XCTAssertTrue([[KeenClient getEventStore] getTotalEventCountWithProjectID:client.projectId] == 3,  @"There should be 3 events after an import.");
+    XCTAssertTrue([[KeenClient getEventStore] getTotalEventCountWithProjectID:client.projectID] == 3,  @"There should be 3 events after an import.");
     XCTAssertFalse([manager fileExistsAtPath:[self keenDirectory] isDirectory:true], @"The Keen directory should be gone.");
 }
 
 - (void)testSDKVersion {
-    KeenClient *client = [KeenClient sharedClientWithProjectId:@"id" andWriteKey:@"wk" andReadKey:@"rk"];
+    KeenClient *client = [KeenClient sharedClientWithProjectID:@"id" andWriteKey:@"wk" andReadKey:@"rk"];
     client.isRunningTests = YES;
     
     // result from class method should equal the SDK Version constant
@@ -1408,7 +1408,7 @@
 }
 
 - (void)testSDKVersionInstanceClient {
-    KeenClient *client = [[KeenClient alloc] initWithProjectId:@"id" andWriteKey:@"wk" andReadKey:@"rk"];
+    KeenClient *client = [[KeenClient alloc] initWithProjectID:@"id" andWriteKey:@"wk" andReadKey:@"rk"];
     client.isRunningTests = YES;
     
     // result from class method should equal the SDK Version constant

--- a/KeenClientTests/KeenClientTests.m
+++ b/KeenClientTests/KeenClientTests.m
@@ -76,7 +76,7 @@
     [super tearDown];
 }
 
-- (void)testInitWithProjectId{
+- (void)testInitWithProjectID{
     KeenClient *client = [[KeenClient alloc] initWithProjectId:@"something" andWriteKey:@"wk" andReadKey:@"rk"];
     XCTAssertEqualObjects(@"something", client.projectId, @"init with a valid project id should work");
     XCTAssertEqualObjects(@"wk", client.writeKey, @"init with a valid project id should work");
@@ -222,7 +222,7 @@
     [client addEvent:@{@"a": @"b"} withKeenProperties:keenProperties toEventCollection:@"foo" error:nil];
     [clientI addEvent:@{@"a": @"b"} withKeenProperties:keenProperties toEventCollection:@"foo" error:nil];
 
-    NSDictionary *eventsForCollection = [[[KeenClient getEventStore] getEventsWithMaxAttempts:3] objectForKey:@"foo"];
+    NSDictionary *eventsForCollection = [[[KeenClient getEventStore] getEventsWithMaxAttempts:3 andProjectID:client.projectId] objectForKey:@"foo"];
     // Grab the first event we get back
     NSData *eventData = [eventsForCollection objectForKey:[[eventsForCollection allKeys] objectAtIndex:0]];
     NSError *error = nil;
@@ -247,7 +247,7 @@
     [client addEvent:@{@"a": @"b"} withKeenProperties:keenProperties toEventCollection:@"foo" error:nil];
     [clientI addEvent:@{@"a": @"b"} withKeenProperties:keenProperties toEventCollection:@"foo" error:nil];
 
-    NSDictionary *eventsForCollection = [[[KeenClient getEventStore] getEventsWithMaxAttempts:3] objectForKey:@"foo"];
+    NSDictionary *eventsForCollection = [[[KeenClient getEventStore] getEventsWithMaxAttempts:3 andProjectID:client.projectId] objectForKey:@"foo"];
     // Grab the first event we get back
     NSData *eventData = [eventsForCollection objectForKey:[[eventsForCollection allKeys] objectAtIndex:0]];
     NSError *error = nil;
@@ -270,7 +270,7 @@
 
     [client addEvent:eventDictionary toEventCollection:@"foo" error:nil];
     [clientI addEvent:eventDictionary toEventCollection:@"foo" error:nil];
-    NSDictionary *eventsForCollection = [[[KeenClient getEventStore] getEventsWithMaxAttempts:3] objectForKey:@"foo"];
+    NSDictionary *eventsForCollection = [[[KeenClient getEventStore] getEventsWithMaxAttempts:3 andProjectID:client.projectId] objectForKey:@"foo"];
     // Grab the first event we get back
     NSData *eventData = [eventsForCollection objectForKey:[[eventsForCollection allKeys] objectAtIndex:0]];
     NSError *error = nil;
@@ -294,7 +294,7 @@
     [client addEvent:@{@"a": @"b"} toEventCollection:@"foo" error:nil];
     [clientI addEvent:@{@"a": @"b"} toEventCollection:@"foo" error:nil];
     // now get the stored event
-    NSDictionary *eventsForCollection = [[[KeenClient getEventStore] getEventsWithMaxAttempts:3] objectForKey:@"foo"];
+    NSDictionary *eventsForCollection = [[[KeenClient getEventStore] getEventsWithMaxAttempts:3 andProjectID:client.projectId] objectForKey:@"foo"];
     // Grab the first event we get back
     NSData *eventData = [eventsForCollection objectForKey:[[eventsForCollection allKeys] objectAtIndex:0]];
     NSError *error = nil;
@@ -320,7 +320,7 @@
     // now get the stored event
 
     // Grab the first event we get back
-    NSDictionary *eventsForCollection = [[[KeenClient getEventStore] getEventsWithMaxAttempts:3] objectForKey:@"bar"];
+    NSDictionary *eventsForCollection = [[[KeenClient getEventStore] getEventsWithMaxAttempts:3 andProjectID:client.projectId] objectForKey:@"bar"];
     // Grab the first event we get back
     NSData *eventData = [eventsForCollection objectForKey:[[eventsForCollection allKeys] objectAtIndex:0]];
     NSError *error = nil;
@@ -367,7 +367,7 @@
     XCTAssertNil(error, @"event should add");
     
     // Grab the first event we get back
-    NSDictionary *eventsForCollection = [[[KeenClient getEventStore] getEventsWithMaxAttempts:3] objectForKey:@"foo"];
+    NSDictionary *eventsForCollection = [[[KeenClient getEventStore] getEventsWithMaxAttempts:3 andProjectID:client.projectId] objectForKey:@"foo"];
     // Grab the first event we get back
     NSData *eventData = [eventsForCollection objectForKey:[[eventsForCollection allKeys] objectAtIndex:0]];
     NSDictionary *deserializedDict = [NSJSONSerialization JSONObjectWithData:eventData
@@ -518,7 +518,7 @@
     
     [mock uploadWithFinishedBlock:nil];
     
-    XCTAssertTrue([[KeenClient getEventStore] getTotalEventCount] == 0, @"Upload method should return with message Request data is empty.");
+    XCTAssertTrue([[KeenClient getEventStore] getTotalEventCountWithProjectID:[mock projectId]] == 0, @"Upload method should return with message Request data is empty.");
 }
 
 - (void)testUploadSuccess {
@@ -527,7 +527,7 @@
     [self addSimpleEventAndUploadWithMock:mock];
     
     // make sure the event was deleted from the store
-    XCTAssertTrue([[KeenClient getEventStore] getTotalEventCount] == 0, @"There should be no files after a successful upload.");
+    XCTAssertTrue([[KeenClient getEventStore] getTotalEventCountWithProjectID:[mock projectId]] == 0, @"There should be no files after a successful upload.");
 }
 
 - (void)testUploadSuccessInstanceClient {
@@ -536,7 +536,7 @@
     [self addSimpleEventAndUploadWithMock:mock];
     
     // make sure the event was deleted from the store
-    XCTAssertTrue([[KeenClient getEventStore] getTotalEventCount] == 0, @"There should be no files after a successful upload.");
+    XCTAssertTrue([[KeenClient getEventStore] getTotalEventCountWithProjectID:[mock projectId]] == 0, @"There should be no files after a successful upload.");
 }
 
 - (void)testUploadSuccessCreated {
@@ -545,7 +545,7 @@
     [self addSimpleEventAndUploadWithMock:mock];
     
     // make sure the event was deleted from the store
-    XCTAssertTrue([[KeenClient getEventStore] getTotalEventCount] == 0, @"There should be no files after a successful upload.");
+    XCTAssertTrue([[KeenClient getEventStore] getTotalEventCountWithProjectID:[mock projectId]] == 0, @"There should be no files after a successful upload.");
 }
 
 - (void)testUploadSuccessCreatedInstanceClient {
@@ -554,7 +554,7 @@
     [self addSimpleEventAndUploadWithMock:mock];
     
     // make sure the event was deleted from the store
-    XCTAssertTrue([[KeenClient getEventStore] getTotalEventCount] == 0, @"There should be no files after a successful upload.");
+    XCTAssertTrue([[KeenClient getEventStore] getTotalEventCountWithProjectID:[mock projectId]] == 0, @"There should be no files after a successful upload.");
 }
 
 - (void)testUploadFailedServerDown {
@@ -563,16 +563,16 @@
     [self addSimpleEventAndUploadWithMock:mock];
 
     // make sure the file wasn't deleted from the store
-    XCTAssertTrue([[KeenClient getEventStore] getTotalEventCount] == 1, @"There should be one files after a successful upload.");
+    XCTAssertTrue([[KeenClient getEventStore] getTotalEventCountWithProjectID:[mock projectId]] == 1, @"There should be one files after a successful upload.");
 }
 
 - (void)testUploadFailedServerDownInstanceClient {
-    id mock = [self uploadTestHelperWithDataInstanceClient:nil andStatusCode:HTTPCode500InternalServerError];
+    id mock = [self uploadTestHelperWithDataInstanceClient:[mock projectId] andStatusCode:HTTPCode500InternalServerError];
     
     [self addSimpleEventAndUploadWithMock:mock];
     
     // make sure the file wasn't deleted from the store
-    XCTAssertTrue([[KeenClient getEventStore] getTotalEventCount] == 1, @"There should be one files after a successful upload.");
+    XCTAssertTrue([[KeenClient getEventStore] getTotalEventCountWithProjectID:[mock projectId]] == 1, @"There should be one files after a successful upload.");
 }
 
 - (void)testUploadFailedServerDownNonJsonResponse {
@@ -581,7 +581,7 @@
     [self addSimpleEventAndUploadWithMock:mock];
     
     // make sure the file wasn't deleted locally
-    XCTAssertTrue([[KeenClient getEventStore] getTotalEventCount] == 1, @"There should be one files after a successful upload.");
+    XCTAssertTrue([[KeenClient getEventStore] getTotalEventCountWithProjectID:[mock projectId]] == 1, @"There should be one files after a successful upload.");
 }
 
 - (void)testUploadFailedServerDownNonJsonResponseInstanceClient {
@@ -590,7 +590,7 @@
     [self addSimpleEventAndUploadWithMock:mock];
     
     // make sure the file wasn't deleted locally
-    XCTAssertTrue([[KeenClient getEventStore] getTotalEventCount] == 1, @"There should be one files after a successful upload.");
+    XCTAssertTrue([[KeenClient getEventStore] getTotalEventCountWithProjectID:[mock projectId]] == 1, @"There should be one files after a successful upload.");
 }
 
 
@@ -604,7 +604,7 @@
     [mock uploadWithFinishedBlock:nil];
 
     // make sure the file wasn't deleted from the store
-    XCTAssertTrue([[KeenClient getEventStore] getTotalEventCount] == 1, @"There should be one file after an unsuccessful attempts.");
+    XCTAssertTrue([[KeenClient getEventStore] getTotalEventCountWithProjectID:[mock projectId]] == 1, @"There should be one file after an unsuccessful attempts.");
 
 
     // add another event
@@ -612,19 +612,19 @@
     [mock uploadWithFinishedBlock:nil];
 
     // make sure both filef weren't deleted from the store
-    XCTAssertTrue([[KeenClient getEventStore] getTotalEventCount] == 2, @"There should be two files after 2 unsuccessful attempts.");
+    XCTAssertTrue([[KeenClient getEventStore] getTotalEventCountWithProjectID:[mock projectId]] == 2, @"There should be two files after 2 unsuccessful attempts.");
 
 
     [mock uploadWithFinishedBlock:nil];
 
     // make sure the first file was deleted from the store, but the second one remains
-    XCTAssertTrue([[[KeenClient getEventStore] getEventsWithMaxAttempts:3] allKeys].count == 1, @"There should be one files after 3 unsuccessful attempts.");
+    XCTAssertTrue([[[KeenClient getEventStore] getEventsWithMaxAttempts:3 andProjectID:[mock projectId]] allKeys].count == 1, @"There should be one files after 3 unsuccessful attempts.");
 
 
     [mock uploadWithFinishedBlock:nil];
 
     // make sure both files were delete from the store
-    XCTAssertTrue([[[KeenClient getEventStore] getEventsWithMaxAttempts:3] allKeys].count == 0, @"There should be no files after 3 unsuccessfull attempts.");
+    XCTAssertTrue([[[KeenClient getEventStore] getEventsWithMaxAttempts:3 andProjectID:[mock projectId]] allKeys].count == 0, @"There should be no files after 3 unsuccessfull attempts.");
 }
 
 - (void)testIncrementEvenOnNoResponse {
@@ -638,21 +638,21 @@
     [mock uploadWithFinishedBlock:nil];
 
     // make sure the file wasn't deleted from the store
-    XCTAssertTrue([[KeenClient getEventStore] getTotalEventCount] == 1, @"There should be one event after an unsuccessful attempt.");
+    XCTAssertTrue([[KeenClient getEventStore] getTotalEventCountWithProjectID:[mock projectId]] == 1, @"There should be one event after an unsuccessful attempt.");
 
 
     // add another event
     [mock uploadWithFinishedBlock:nil];
 
     // make sure both filef weren't deleted from the store
-    XCTAssertTrue([[KeenClient getEventStore] getTotalEventCount] == 1, @"There should be one event after 2 unsuccessful attempts.");
+    XCTAssertTrue([[KeenClient getEventStore] getTotalEventCountWithProjectID:[mock projectId]] == 1, @"There should be one event after 2 unsuccessful attempts.");
 
 
     [mock uploadWithFinishedBlock:nil];
 
     // make sure the event was incremented
-    XCTAssertTrue([[[KeenClient getEventStore] getEventsWithMaxAttempts:3] allKeys].count == 0, @"There should be no events with less than 3 unsuccessful attempts.");
-    XCTAssertTrue([[[KeenClient getEventStore] getEventsWithMaxAttempts:4] allKeys].count == 1, @"There should be one event with less than 4 unsuccessful attempts.");
+    XCTAssertTrue([[[KeenClient getEventStore] getEventsWithMaxAttempts:3 andProjectID:[mock projectId]] allKeys].count == 0, @"There should be no events with less than 3 unsuccessful attempts.");
+    XCTAssertTrue([[[KeenClient getEventStore] getEventsWithMaxAttempts:4 andProjectID:[mock projectId]] allKeys].count == 1, @"There should be one event with less than 4 unsuccessful attempts.");
 }
 
 - (void)testUploadFailedBadRequest {
@@ -665,7 +665,7 @@
     
     // make sure the file was deleted locally
     // make sure the event was deleted from the store
-    XCTAssertTrue([[KeenClient getEventStore] getTotalEventCount] == 0,  @"An invalid event should be deleted after an upload attempt.");
+    XCTAssertTrue([[KeenClient getEventStore] getTotalEventCountWithProjectID:nil] == 0,  @"An invalid event should be deleted after an upload attempt.");
 }
 
 - (void)testUploadFailedBadRequestInstanceClient {
@@ -678,7 +678,7 @@
     
     // make sure the file was deleted locally
     // make sure the event was deleted from the store
-    XCTAssertTrue([[KeenClient getEventStore] getTotalEventCount] == 0,  @"An invalid event should be deleted after an upload attempt.");
+    XCTAssertTrue([[KeenClient getEventStore] getTotalEventCountWithProjectID:nil] == 0,  @"An invalid event should be deleted after an upload attempt.");
 }
 
 - (void)testUploadFailedBadRequestUnknownError {
@@ -687,7 +687,7 @@
     [self addSimpleEventAndUploadWithMock:mock];
     
     // make sure the file wasn't deleted locally
-    XCTAssertTrue([[KeenClient getEventStore] getTotalEventCount] == 1, @"An upload that results in an unexpected error should not delete the event.");
+    XCTAssertTrue([[KeenClient getEventStore] getTotalEventCountWithProjectID:[mock projectId]] == 1, @"An upload that results in an unexpected error should not delete the event.");
 }
 
 - (void)testUploadFailedBadRequestUnknownErrorInstanceClient {
@@ -696,7 +696,7 @@
     [self addSimpleEventAndUploadWithMock:mock];
 
     // make sure the file wasn't deleted locally
-    XCTAssertTrue([[KeenClient getEventStore] getTotalEventCount] == 1, @"An upload that results in an unexpected error should not delete the event.");
+    XCTAssertTrue([[KeenClient getEventStore] getTotalEventCountWithProjectID:[mock projectId]] == 1, @"An upload that results in an unexpected error should not delete the event.");
 }
 
 - (void)testUploadFailedRedirectionStatus {
@@ -705,7 +705,7 @@
     [self addSimpleEventAndUploadWithMock:mock];
     
     // make sure the file wasn't deleted locally
-    XCTAssertTrue([[KeenClient getEventStore] getTotalEventCount] == 1, @"An upload that results in an unexpected error should not delete the event.");
+    XCTAssertTrue([[KeenClient getEventStore] getTotalEventCountWithProjectID:[mock projectId]] == 1, @"An upload that results in an unexpected error should not delete the event.");
 }
 
 - (void)testUploadFailedRedirectionStatusInstanceClient {
@@ -714,7 +714,7 @@
     [self addSimpleEventAndUploadWithMock:mock];
     
     // make sure the file wasn't deleted locally
-    XCTAssertTrue([[KeenClient getEventStore] getTotalEventCount] == 1, @"An upload that results in an unexpected error should not delete the event.");
+    XCTAssertTrue([[KeenClient getEventStore] getTotalEventCountWithProjectID:[mock projectId]] == 1, @"An upload that results in an unexpected error should not delete the event.");
 }
 
 - (void)testUploadSkippedNoNetwork {
@@ -724,7 +724,7 @@
     [self addSimpleEventAndUploadWithMock:mock];
 
     // make sure the file wasn't deleted locally
-    XCTAssertTrue([[KeenClient getEventStore] getTotalEventCount] == 1, @"An upload with no network should not delete the event.");
+    XCTAssertTrue([[KeenClient getEventStore] getTotalEventCountWithProjectID:[mock projectId]] == 1, @"An upload with no network should not delete the event.");
 }
 
 - (void)testUploadMultipleEventsSameCollectionSuccess {
@@ -746,7 +746,7 @@
     [mock uploadWithFinishedBlock:nil];
     
     // make sure the events were deleted locally
-    XCTAssertTrue([[KeenClient getEventStore] getTotalEventCount] == 0,  @"There should be no files after a successful upload.");
+    XCTAssertTrue([[KeenClient getEventStore] getTotalEventCountWithProjectID:nil] == 0,  @"There should be no files after a successful upload.");
 }
 
 - (void)testUploadMultipleEventsSameCollectionSuccessInstanceClient {
@@ -768,7 +768,7 @@
     [mock uploadWithFinishedBlock:nil];
     
     // make sure the events were deleted locally
-    XCTAssertTrue([[KeenClient getEventStore] getTotalEventCount] == 0,  @"There should be no files after a successful upload.");
+    XCTAssertTrue([[KeenClient getEventStore] getTotalEventCountWithProjectID:nil] == 0,  @"There should be no files after a successful upload.");
 }
 
 - (void)testUploadMultipleEventsDifferentCollectionSuccess {
@@ -791,7 +791,7 @@
     [mock uploadWithFinishedBlock:nil];
     
     // make sure the files were deleted locally
-    XCTAssertTrue([[KeenClient getEventStore] getTotalEventCount] == 0,  @"There should be no events after a successful upload.");
+    XCTAssertTrue([[KeenClient getEventStore] getTotalEventCountWithProjectID:nil] == 0,  @"There should be no events after a successful upload.");
 }
 
 - (void)testUploadMultipleEventsDifferentCollectionSuccessInstanceClient {
@@ -814,7 +814,7 @@
     [mock uploadWithFinishedBlock:nil];
     
     // make sure the files were deleted locally
-    XCTAssertTrue([[KeenClient getEventStore] getTotalEventCount] == 0,  @"There should be no events after a successful upload.");
+    XCTAssertTrue([[KeenClient getEventStore] getTotalEventCountWithProjectID:nil] == 0,  @"There should be no events after a successful upload.");
 }
 
 - (void)testUploadMultipleEventsSameCollectionOneFails {
@@ -836,7 +836,7 @@
     [mock uploadWithFinishedBlock:nil];
 
     // make sure the file were deleted locally
-    XCTAssertTrue([[KeenClient getEventStore] getTotalEventCount] == 0,  @"There should be no events after a successful upload.");
+    XCTAssertTrue([[KeenClient getEventStore] getTotalEventCountWithProjectID:[mock projectId]] == 0,  @"There should be no events after a successful upload.");
 }
 
 - (void)testUploadMultipleEventsSameCollectionOneFailsInstanceClient {
@@ -858,7 +858,7 @@
     [mock uploadWithFinishedBlock:nil];
     
     // make sure the file were deleted locally
-    XCTAssertTrue([[KeenClient getEventStore] getTotalEventCount] == 0,  @"There should be no events after a successful upload.");
+    XCTAssertTrue([[KeenClient getEventStore] getTotalEventCountWithProjectID:[mock projectId]] == 0,  @"There should be no events after a successful upload.");
 }
 
 - (void)testUploadMultipleEventsDifferentCollectionsOneFails {
@@ -881,7 +881,7 @@
     [mock uploadWithFinishedBlock:nil];
 
     // make sure the files were deleted locally
-    XCTAssertTrue([[KeenClient getEventStore] getTotalEventCount] == 0,  @"There should be no events after a successful upload.");
+    XCTAssertTrue([[KeenClient getEventStore] getTotalEventCountWithProjectID:[mock projectId]] == 0,  @"There should be no events after a successful upload.");
 }
 
 - (void)testUploadMultipleEventsDifferentCollectionsOneFailsInstanceClient {
@@ -904,7 +904,7 @@
     [mock uploadWithFinishedBlock:nil];
     
     // make sure the files were deleted locally
-    XCTAssertTrue([[KeenClient getEventStore] getTotalEventCount] == 0,  @"There should be no events after a successful upload.");
+    XCTAssertTrue([[KeenClient getEventStore] getTotalEventCountWithProjectID:[mock projectId]] == 0,  @"There should be no events after a successful upload.");
 }
 
 - (void)testUploadMultipleEventsDifferentCollectionsOneFailsForServerReason {
@@ -927,7 +927,7 @@
     [mock uploadWithFinishedBlock:nil];
 
     // make sure the files were deleted locally
-    XCTAssertTrue([[KeenClient getEventStore] getTotalEventCount] == 1,  @"There should be 1 events after a partial upload.");
+    XCTAssertTrue([[KeenClient getEventStore] getTotalEventCountWithProjectID:[mock projectId]] == 1,  @"There should be 1 events after a partial upload.");
 }
 
 - (void)testUploadMultipleEventsDifferentCollectionsOneFailsForServerReasonInstanceClient {
@@ -950,7 +950,7 @@
     [mock uploadWithFinishedBlock:nil];
     
     // make sure the files were deleted locally
-    XCTAssertTrue([[KeenClient getEventStore] getTotalEventCount] == 1,  @"There should be 1 events after a partial upload.");
+    XCTAssertTrue([[KeenClient getEventStore] getTotalEventCountWithProjectID:[mock projectId]] == 1,  @"There should be 1 events after a partial upload.");
 }
 
 - (void)testTooManyEventsCached {
@@ -961,11 +961,11 @@
     for (int i=0; i<5; i++) {
         [client addEvent:event toEventCollection:@"something" error:nil];
     }
-    XCTAssertTrue([[KeenClient getEventStore] getTotalEventCount] == 5,  @"There should be exactly five events.");
+    XCTAssertTrue([[KeenClient getEventStore] getTotalEventCountWithProjectID:client.projectId] == 5,  @"There should be exactly five events.");
     // now do one more, should age out 1 old ones
     [client addEvent:event toEventCollection:@"something" error:nil];
     // so now there should be 4 left (5 - 2 + 1)
-    XCTAssertTrue([[KeenClient getEventStore] getTotalEventCount] == 4, @"There should be exactly five events.");
+    XCTAssertTrue([[KeenClient getEventStore] getTotalEventCountWithProjectID:client.projectId] == 4, @"There should be exactly five events.");
 }
 
 - (void)testTooManyEventsCachedInstanceClient {
@@ -976,11 +976,11 @@
     for (int i=0; i<5; i++) {
         [client addEvent:event toEventCollection:@"something" error:nil];
     }
-    XCTAssertTrue([[KeenClient getEventStore] getTotalEventCount] == 5,  @"There should be exactly five events.");
+    XCTAssertTrue([[KeenClient getEventStore] getTotalEventCountWithProjectID:client.projectId] == 5,  @"There should be exactly five events.");
     // now do one more, should age out 1 old ones
     [client addEvent:event toEventCollection:@"something" error:nil];
     // so now there should be 4 left (5 - 2 + 1)
-    XCTAssertTrue([[KeenClient getEventStore] getTotalEventCount] == 4, @"There should be exactly five events.");
+    XCTAssertTrue([[KeenClient getEventStore] getTotalEventCountWithProjectID:client.projectId] == 4, @"There should be exactly five events.");
 }
 
 - (void)testGlobalPropertiesDictionary {
@@ -993,7 +993,7 @@
         client.globalPropertiesDictionary = globalProperties;
         NSDictionary *event = @{@"foo": @"bar"};
         [client addEvent:event toEventCollection:eventCollectionName error:nil];
-        NSDictionary *eventsForCollection = [[[KeenClient getEventStore] getEventsWithMaxAttempts:3] objectForKey:eventCollectionName];
+        NSDictionary *eventsForCollection = [[[KeenClient getEventStore] getEventsWithMaxAttempts:3 andProjectID:client.projectId] objectForKey:eventCollectionName];
         // Grab the first event we get back
         NSData *eventData = [eventsForCollection objectForKey:[[eventsForCollection allKeys] objectAtIndex:0]];
         NSError *error = nil;
@@ -1048,7 +1048,7 @@
         client.globalPropertiesDictionary = globalProperties;
         NSDictionary *event = @{@"foo": @"bar"};
         [client addEvent:event toEventCollection:eventCollectionName error:nil];
-        NSDictionary *eventsForCollection = [[[KeenClient getEventStore] getEventsWithMaxAttempts:3] objectForKey:eventCollectionName];
+        NSDictionary *eventsForCollection = [[[KeenClient getEventStore] getEventsWithMaxAttempts:3 andProjectID:client.projectId] objectForKey:eventCollectionName];
         // Grab the first event we get back
         NSData *eventData = [eventsForCollection objectForKey:[[eventsForCollection allKeys] objectAtIndex:0]];
         NSError *error = nil;
@@ -1104,7 +1104,7 @@
         NSDictionary *event = @{@"foo": @"bar"};
         [client addEvent:event toEventCollection:eventCollectionName error:nil];
 
-        NSDictionary *eventsForCollection = [[[KeenClient getEventStore] getEventsWithMaxAttempts:3] objectForKey:eventCollectionName];
+        NSDictionary *eventsForCollection = [[[KeenClient getEventStore] getEventsWithMaxAttempts:3 andProjectID:client.projectId] objectForKey:eventCollectionName];
         // Grab the first event we get back
         NSData *eventData = [eventsForCollection objectForKey:[[eventsForCollection allKeys] objectAtIndex:0]];
         NSError *error = nil;
@@ -1167,7 +1167,7 @@
         NSDictionary *event = @{@"foo": @"bar"};
         [client addEvent:event toEventCollection:eventCollectionName error:nil];
         
-        NSDictionary *eventsForCollection = [[[KeenClient getEventStore] getEventsWithMaxAttempts:3] objectForKey:eventCollectionName];
+        NSDictionary *eventsForCollection = [[[KeenClient getEventStore] getEventsWithMaxAttempts:3 andProjectID:client.projectId] objectForKey:eventCollectionName];
         // Grab the first event we get back
         NSData *eventData = [eventsForCollection objectForKey:[[eventsForCollection allKeys] objectAtIndex:0]];
         NSError *error = nil;
@@ -1231,7 +1231,7 @@
     };
     [client addEvent:@{@"foo": @"bar"} toEventCollection:@"apples" error:nil];
 
-    NSDictionary *eventsForCollection = [[[KeenClient getEventStore] getEventsWithMaxAttempts:3] objectForKey:@"apples"];
+    NSDictionary *eventsForCollection = [[[KeenClient getEventStore] getEventsWithMaxAttempts:3 andProjectID:client.projectId] objectForKey:@"apples"];
     // Grab the first event we get back
     NSData *eventData = [eventsForCollection objectForKey:[[eventsForCollection allKeys] objectAtIndex:0]];
     NSError *error = nil;
@@ -1256,7 +1256,7 @@
     };
     [client addEvent:@{@"foo": @"bar"} toEventCollection:@"apples" error:nil];
     
-    NSDictionary *eventsForCollection = [[[KeenClient getEventStore] getEventsWithMaxAttempts:3] objectForKey:@"apples"];
+    NSDictionary *eventsForCollection = [[[KeenClient getEventStore] getEventsWithMaxAttempts:3 andProjectID:client.projectId] objectForKey:@"apples"];
     // Grab the first event we get back
     NSData *eventData = [eventsForCollection objectForKey:[[eventsForCollection allKeys] objectAtIndex:0]];
     NSError *error = nil;
@@ -1359,7 +1359,7 @@
     NSDictionary *event3 = @{@"nested": @{@"keen": @"whatever"}};
     [client addEvent:event3 toEventCollection:@"foo" error:nil];
 
-    XCTAssertTrue([[KeenClient getEventStore] getTotalEventCount] == 3,  @"There should be 3 events after an import.");
+    XCTAssertTrue([[KeenClient getEventStore] getTotalEventCountWithProjectID:client.projectId] == 3,  @"There should be 3 events after an import.");
     XCTAssertFalse([manager fileExistsAtPath:[self keenDirectory] isDirectory:true], @"The Keen directory should be gone.");
 }
 
@@ -1394,7 +1394,7 @@
     NSDictionary *event3 = @{@"nested": @{@"keen": @"whatever"}};
     [client addEvent:event3 toEventCollection:@"foo" error:nil];
     
-    XCTAssertTrue([[KeenClient getEventStore] getTotalEventCount] == 3,  @"There should be 3 events after an import.");
+    XCTAssertTrue([[KeenClient getEventStore] getTotalEventCountWithProjectID:client.projectId] == 3,  @"There should be 3 events after an import.");
     XCTAssertFalse([manager fileExistsAtPath:[self keenDirectory] isDirectory:true], @"The Keen directory should be gone.");
 }
 

--- a/KeenSwiftClientExample/KeenSwiftClientExample/AppDelegate.swift
+++ b/KeenSwiftClientExample/KeenSwiftClientExample/AppDelegate.swift
@@ -19,7 +19,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         KeenClient.enableLogging();
         
         var client : KeenClient;
-        client = KeenClient.sharedClientWithProjectId("project_id", andWriteKey: "wk", andReadKey: "rk");
+        client = KeenClient.sharedClientWithProjectID("project_id", andWriteKey: "wk", andReadKey: "rk");
 
         client.globalPropertiesBlock = {(eventCollection : String!) -> [NSObject : AnyObject]! in
             return [ "GLOBALS": "YEAH WHAT SWIFT"]


### PR DESCRIPTION
This PR closes #108 

KeenClient only has a static reference to a KIOEventStore variable, and KIOEventStore had a "projectID" property. That was being set whenever a shared KeenClient or an instance was initialized, which meant all events would go to the last set projectID.

I fixed that by removing the "projectID" variable from KIOEventStore, and making the projectID a parameter of all its required methods.

This PR can be tested by following the instructions on #108 