### PR TITLE
Fix SQLite database not recording events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 
 ## [Unreleased][unreleased]
+### Fixed
+- Fixed sqlite migration error that was starting a transaction and not finishing it,  keeping events from being saved. #113
 
 ## [3.4.1] - 2015-07-22
 ### Fixed


### PR DESCRIPTION
This PR closes #113.

`beginTransaction` was being called in KIOEventStore, and when no migration was done it wouldn't finish the transaction. That was stopping any other SQL write operation from being done. This makes sure that the initial SQL migration transaction is closed, even when there's no migration.

You can test this PR by running the sample app in the simulator, and checking the `keenEvents.sqlite` file for new events being added there.