### PR TITLE
Fix for objects different from NSString

### DIFF
--- a/KeenClient/KeenClient.m
+++ b/KeenClient/KeenClient.m
@@ -1123,11 +1123,11 @@ static KIODBStore *dbStore;
         
         //check that Keen queries have the same parameters
         for (NSString *key in [multiAnalysisDictionary allKeys]) {
-            NSString *queryProperty = [[query propertiesDictionary] objectForKey:key];
+            NSObject *queryProperty = [[query propertiesDictionary] objectForKey:key];
             if (queryProperty != nil) {
                 if ([multiAnalysisDictionary objectForKey:key] == [NSNull null]) {
                     [multiAnalysisDictionary setObject:queryProperty forKey:key];
-                } else if (![[multiAnalysisDictionary    objectForKey:key] isEqualToString:queryProperty]) {
+                } else if (![[multiAnalysisDictionary objectForKey:key] isEqual:queryProperty]) {
                     KCLog(@"queries %@ property doesn't match", key);
                     return nil;
                 }


### PR DESCRIPTION
Timeframe and Filters parameters on multi-analysis requests may be NSObjects or NSArrays instead of NSString.

Small change but I thought it'd be better to open a PR as well. 💃