### PR TITLE
Remove db file if it becomes corrupt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,9 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Removed Makefile in favor of `/bin/test.sh`.
 - Removed unused docs folder and `generate_docs.sh` script.
 
+### Fixed
+- Fixed bug where an app would crash in case the database was corrupted, by checking for the `SQLITE_CORRUPT` flag when database is opened, and deleting it if true.  #121
+
 ## [3.5.2] - 2016-02-04
 ### Added
 - Added support for Carthage. Added a Dynamic Framework scheme, and changed its setting to "Shared" so Carthage can use it.

--- a/KeenClient/KIODBStore.m
+++ b/KeenClient/KIODBStore.m
@@ -78,10 +78,22 @@
         keen_io_sqlite3_config(SQLITE_CONFIG_MULTITHREAD);
         keen_io_sqlite3_initialize();
         
-        if (keen_io_sqlite3_open([my_sqlfile UTF8String], &keen_dbname) == SQLITE_OK) {
-            wasOpened = YES;
+        int openDBResult = keen_io_sqlite3_open([my_sqlfile UTF8String], &keen_dbname);
+        if (openDBResult != SQLITE_OK) {
+            if(openDBResult == SQLITE_CORRUPT) {
+                // delete corrupt database file
+                NSError *error = nil;
+                NSLog(@"%@", my_sqlfile);
+                [[NSFileManager defaultManager] removeItemAtPath:my_sqlfile error:&error];
+                
+                // create new database file
+                [self openDB];
+            }
+            else {
+                [self handleSQLiteFailure:@"create database"];
+            }
         } else {
-            [self handleSQLiteFailure:@"create database"];
+            wasOpened = YES;
         }
         dbIsOpen = wasOpened;
     });

--- a/KeenClient/KeenClient.m
+++ b/KeenClient/KeenClient.m
@@ -608,8 +608,11 @@ static KIODBStore *dbStore;
     } else if ([value isKindOfClass:[KeenProperties class]]) {
         KeenProperties *keenProperties = value;
         
+        NSMutableDictionary *dict = [[NSMutableDictionary alloc] init];
         NSString *isoDate = [self convertDate:keenProperties.timestamp];
-        NSMutableDictionary *dict = [NSMutableDictionary dictionaryWithObject:isoDate forKey:@"timestamp"];
+        if (isoDate != nil) {
+            [dict setObject:isoDate forKey:@"timestamp"];
+        }
         
         CLLocation *location = keenProperties.location;
         if (location != nil) {


### PR DESCRIPTION
This PR fixes #121.

It checks for the `SQLITE_CORRUPT` flag when opening the database, and removes the database file in case it's true.

It also adds a safety check for adding the timestamp property to an event dictionary in case it's nil, so it won't crash a user's app.