### PR TITLE
Fix prefix header path in build settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 
 ## [Unreleased][unreleased]
+### Fixed
+- Fixed Xcode `KeenClient-Prefix.pch.pch: No such file or directory` warnings when compiling app.
 
 ## [3.5.3] - 2016-03-28
 ### Added

--- a/KeenClient.xcodeproj/project.pbxproj
+++ b/KeenClient.xcodeproj/project.pbxproj
@@ -811,7 +811,7 @@
 				GCC_GENERATE_TEST_COVERAGE_FILES = NO;
 				GCC_INSTRUMENT_PROGRAM_FLOW_ARCS = NO;
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
-				GCC_PREFIX_HEADER = "KeenClient/KeenClient-Prefix.pch";
+				GCC_PREFIX_HEADER = "$(PROJECT_DIR)/KeenClient/KeenClient-Prefix.pch";
 				GCC_PREPROCESSOR_DEFINITIONS = "$(inherited)";
 				"GCC_PREPROCESSOR_DEFINITIONS[arch=*]" = "$(inherited)";
 				GCC_THUMB_SUPPORT = NO;
@@ -833,7 +833,7 @@
 				CLANG_ENABLE_OBJC_ARC = YES;
 				DSTROOT = /tmp/KeenClient.dst;
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
-				GCC_PREFIX_HEADER = "KeenClient/KeenClient-Prefix.pch";
+				GCC_PREFIX_HEADER = "$(PROJECT_DIR)/KeenClient/KeenClient-Prefix.pch";
 				GCC_THUMB_SUPPORT = NO;
 				IPHONEOS_DEPLOYMENT_TARGET = 7.0;
 				LIBRARY_SEARCH_PATHS = (
@@ -855,7 +855,7 @@
 				DEBUG_INFORMATION_FORMAT = dwarf;
 				FRAMEWORK_SEARCH_PATHS = "$(inherited)";
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
-				GCC_PREFIX_HEADER = "KeenClient/KeenClient-Prefix.pch";
+				GCC_PREFIX_HEADER = "$(PROJECT_DIR)/KeenClient/KeenClient-Prefix.pch";
 				GCC_PREPROCESSOR_DEFINITIONS = (
 					"KEEN_DEBUG=1",
 					"$(inherited)",
@@ -885,7 +885,7 @@
 				DEBUG_INFORMATION_FORMAT = dwarf;
 				FRAMEWORK_SEARCH_PATHS = "$(inherited)";
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
-				GCC_PREFIX_HEADER = "KeenClient/KeenClient-Prefix.pch";
+				GCC_PREFIX_HEADER = "$(PROJECT_DIR)/KeenClient/KeenClient-Prefix.pch";
 				HEADER_SEARCH_PATHS = "${PROJECT_DIR}/**";
 				INFOPLIST_FILE = "KeenClientTests/KeenClientTests-Info.plist";
 				IPHONEOS_DEPLOYMENT_TARGET = 7.0;


### PR DESCRIPTION
This PR fixes #152.

It's a small change in the `Prefix Header` path for the project's Build Settings, adding `$(PROJECT_DIR)` to the beginning.