### PR TITLE
SQLite Fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 
 ## [Unreleased][unreleased]
+### Fixed
+- Fixed handling of SQLite errors on `getEventsWithMaxAttempts`, `closeDB`, and `prepareAllSQLiteStatements` methods.
 
 ## [3.5.4] - 2016-06-13
 ### Fixed

--- a/KeenClient/KIODBStore.m
+++ b/KeenClient/KIODBStore.m
@@ -422,10 +422,12 @@
     dispatch_sync(self.dbQueue, ^{
         if (keen_io_sqlite3_bind_text(find_event_stmt, 1, projectIDUTF8, -1, SQLITE_STATIC) != SQLITE_OK) {
             [self handleSQLiteFailure:@"bind pid to find statement"];
+            return;
         }
         
         if(keen_io_sqlite3_bind_int64(find_event_stmt, 2, maxAttempts) != SQLITE_OK) {
             [self handleSQLiteFailure:@"bind coll to add event statement"];
+            return;
         }
 
 
@@ -443,9 +445,11 @@
             // Bind and mark the event pending.
             if(keen_io_sqlite3_bind_int64(make_pending_event_stmt, 1, eventId) != SQLITE_OK) {
                 [self handleSQLiteFailure:@"bind int for make pending"];
+                return;
             }
             if (keen_io_sqlite3_step(make_pending_event_stmt) != SQLITE_DONE) {
                 [self handleSQLiteFailure:@"mark event pending"];
+                return;
             }
 
             // Reset the pendifier

--- a/KeenClient/KIODBStore.m
+++ b/KeenClient/KIODBStore.m
@@ -128,33 +128,35 @@
 
 - (void)closeDB {
     // Free all the prepared statements. This is safe on null pointers.
-    keen_io_sqlite3_finalize(insert_event_stmt);
-    keen_io_sqlite3_finalize(find_event_stmt);
-    keen_io_sqlite3_finalize(count_all_events_stmt);
-    keen_io_sqlite3_finalize(count_pending_events_stmt);
-    keen_io_sqlite3_finalize(make_pending_event_stmt);
-    keen_io_sqlite3_finalize(reset_pending_events_stmt);
-    keen_io_sqlite3_finalize(purge_events_stmt);
-    keen_io_sqlite3_finalize(delete_event_stmt);
-    keen_io_sqlite3_finalize(delete_all_events_stmt);
-    keen_io_sqlite3_finalize(increment_event_attempts_statement);
-    keen_io_sqlite3_finalize(delete_too_many_attempts_events_statement);
-    keen_io_sqlite3_finalize(age_out_events_stmt);
-    
-    keen_io_sqlite3_finalize(insert_query_stmt);
-    keen_io_sqlite3_finalize(count_all_queries_stmt);
-    keen_io_sqlite3_finalize(get_query_stmt);
-    keen_io_sqlite3_finalize(increment_query_attempts_statement);
-    keen_io_sqlite3_finalize(delete_all_queries_stmt);
-    keen_io_sqlite3_finalize(get_query_with_attempts_stmt);
-    keen_io_sqlite3_finalize(age_out_queries_stmt);
-    
-    keen_io_sqlite3_finalize(convert_date_stmt);
-    
-    // Free our DB. This is safe on null pointers.
-    keen_io_sqlite3_close(keen_dbname);
-    // Reset state in case it matters.
-    dbIsOpen = NO;
+    if(dbIsOpen) {
+        keen_io_sqlite3_finalize(insert_event_stmt);
+        keen_io_sqlite3_finalize(find_event_stmt);
+        keen_io_sqlite3_finalize(count_all_events_stmt);
+        keen_io_sqlite3_finalize(count_pending_events_stmt);
+        keen_io_sqlite3_finalize(make_pending_event_stmt);
+        keen_io_sqlite3_finalize(reset_pending_events_stmt);
+        keen_io_sqlite3_finalize(purge_events_stmt);
+        keen_io_sqlite3_finalize(delete_event_stmt);
+        keen_io_sqlite3_finalize(delete_all_events_stmt);
+        keen_io_sqlite3_finalize(increment_event_attempts_statement);
+        keen_io_sqlite3_finalize(delete_too_many_attempts_events_statement);
+        keen_io_sqlite3_finalize(age_out_events_stmt);
+        
+        keen_io_sqlite3_finalize(insert_query_stmt);
+        keen_io_sqlite3_finalize(count_all_queries_stmt);
+        keen_io_sqlite3_finalize(get_query_stmt);
+        keen_io_sqlite3_finalize(increment_query_attempts_statement);
+        keen_io_sqlite3_finalize(delete_all_queries_stmt);
+        keen_io_sqlite3_finalize(get_query_with_attempts_stmt);
+        keen_io_sqlite3_finalize(age_out_queries_stmt);
+        
+        keen_io_sqlite3_finalize(convert_date_stmt);
+        
+        // Free our DB. This is safe on null pointers.
+        keen_io_sqlite3_close(keen_dbname);
+        // Reset state in case it matters.
+        dbIsOpen = NO;
+    }
 }
 
 - (BOOL)createTables {


### PR DESCRIPTION
This PR fixes a few methods (`getEventsWithMaxAttempts`, `closeDB`, and `prepareAllSQLiteStatements`) that were not correctly handling SQLite errors.