### PR TITLE
Fix SQLite date conversion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 
 ## [Unreleased][unreleased]
+### Fixed
+- Fixed app crashing when NSDate conversion to ISO8601 failed. Removed dependency on SQLite to convert date in favor of NSDateFormatter, which is thread-safe on iOS >=7 and OS X >=10.9. #165
 
 ## [3.5.5] - 2016-06-28
 ### Fixed

--- a/KeenClient/KIODBStore.h
+++ b/KeenClient/KIODBStore.h
@@ -68,12 +68,6 @@
   */
 - (void)incrementEventUploadAttempts: (NSNumber *)eventId;
 
- /**
-  Convert an NSDate to ISO-8601 using SQLite (thread safe)
- 
-  @param date A date.
-  */
-- (id)convertNSDateToISO8601:(NSDate *)date;
 
  /**
   Delete events starting at an offset. Helps to keep the "queue" bounded.

--- a/KeenClient/KIODBStore.m
+++ b/KeenClient/KIODBStore.m
@@ -710,6 +710,7 @@
 }
 
 # pragma makr - Handle Queries
+# pragma mark - Handle Queries
 
 - (BOOL)addQuery:(NSData *)queryData queryType:(NSString *)queryType collection:(NSString *)eventCollection projectID:(NSString *)projectID {
     __block BOOL wasAdded = NO;

--- a/KeenClient/KeenClient.m
+++ b/KeenClient/KeenClient.m
@@ -1159,24 +1159,6 @@ static KIODBStore *dbStore;
     return string;
 }
 
-- (id)handleUnsupportedJSONValue:(id)value {
-    if ([value isKindOfClass:[NSDate class]]) {
-        return [self convertDate:value];
-    } else if ([value isKindOfClass:[KeenProperties class]]) {
-        KeenProperties *keenProperties = (KeenProperties *)value;
-        NSMutableDictionary *dict = [NSMutableDictionary dictionaryWithObject:keenProperties.timestamp forKey:@"timestamp"];
-        CLLocation *location = keenProperties.location;
-        if (location != nil) {
-            NSNumber *longitude = [NSNumber numberWithDouble:location.coordinate.longitude];
-            NSNumber *latitude = [NSNumber numberWithDouble:location.coordinate.latitude];
-            NSArray *coordinatesArray = [NSArray arrayWithObjects:longitude, latitude, nil];
-            NSDictionary *coordinatesDict = [NSDictionary dictionaryWithObject:coordinatesArray forKey:@"coordinates"];
-            [dict setObject:coordinatesDict forKey:@"location"];
-        }
-        return dict;
-    }
-    return NULL;
-}
 
 # pragma mark - SDK
 

--- a/KeenClient/KeenClient.m
+++ b/KeenClient/KeenClient.m
@@ -158,7 +158,7 @@ static KIODBStore *dbStore;
  @return Always return NO.
  */
 - (BOOL)handleError:(NSError **)error withErrorMessage:(NSString *)errorMessage;
-    
+
 @end
 
 @implementation KeenClient
@@ -1155,10 +1155,14 @@ static KIODBStore *dbStore;
 # pragma mark - NSDate => NSString
 
 - (id)convertDate:(id)date {
-    NSString *string = [dbStore convertNSDateToISO8601:date];
-    return string;
+    NSDateFormatter *dateFormatter = [[NSDateFormatter alloc] init];
+    NSLocale *enUSPOSIXLocale = [NSLocale localeWithLocaleIdentifier:@"en_US_POSIX"];
+    [dateFormatter setLocale:enUSPOSIXLocale];
+    [dateFormatter setDateFormat:@"yyyy-MM-dd'T'HH:mm:ssZZZZZ"];
+    
+    NSString *iso8601String = [dateFormatter stringFromDate:date];
+    return iso8601String;
 }
-
 
 # pragma mark - SDK
 


### PR DESCRIPTION
This PR closes #165.

The SDK was using SQLite to convert an `NSDate` object to an ISO8601 string because Apple's `NSDateFormatter` class wasn't thread-safe. Since iOS 7 and OS X 10.9 the class is thread-safe ([link](https://developer.apple.com/library/mac/documentation/Cocoa/Reference/Foundation/Classes/NSDateFormatter_Class/)), so this PR removes the `convertNSDateToISO8601` method from the `KIODBStore` class, and converts the date directly in the `KeenClient` class using an `NSDateFormatter`.