### PR TITLE
Disable location request

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ## [Unreleased][unreleased]
 ### Changed
 - Updated Swift example project to Swift 3 syntax. #175
+- Added method to disable automatically requesting CoreLocation authentication.
 
 ## [3.5.6] - 2016-08-05
 ### Fixed

--- a/KeenClient/KeenClient.h
+++ b/KeenClient/KeenClient.h
@@ -168,6 +168,14 @@ typedef NSDictionary* (^KeenGlobalPropertiesBlock)(NSString *eventCollection);
 + (void)enableGeoLocation;
 
 /**
+ Call this to prevent keen from requesting geo location permissions. You want to use this if you want to control
+ when the user recieves the geo location permissiosn request
+ 
+ Geo location request is ENABLED by default.
+ */
++ (void)disableGeoLocationDefaultRequest;
+
+/**
  Call this to disable debug logging. It's disabled by default.
  */
 + (void)disableLogging;

--- a/KeenClient/KeenClient.h
+++ b/KeenClient/KeenClient.h
@@ -168,6 +168,13 @@ typedef NSDictionary* (^KeenGlobalPropertiesBlock)(NSString *eventCollection);
 + (void)enableGeoLocation;
 
 /**
+ Call this to ask keen to request geo location permissions for you.
+ 
+ Geo location request is ENABLED by default.
+ */
++ (void)enableGeoLocationDefaultRequest;
+
+/**
  Call this to prevent keen from requesting geo location permissions. You want to use this if you want to control
  when the user recieves the geo location permissiosn request
  

--- a/KeenClient/KeenClient.m
+++ b/KeenClient/KeenClient.m
@@ -413,13 +413,13 @@ static KIODBStore *dbStore;
 }
 
 +(BOOL)isLocationAuthorized:(CLAuthorizationStatus)status {
-#if TARGET_OS_MAC
-  if (status == kCLAuthorizationStatusAuthorized) {
-    return YES;
-  }
-#else
+#if TARGET_OS_IOS
   if (status == kCLAuthorizationStatusAuthorizedWhenInUse ||
       status == kCLAuthorizationStatusAuthorizedAlways) {
+    return YES;
+  }
+#elif TARGET_OS_MAC
+  if (status == kCLAuthorizationStatusAuthorized) {
     return YES;
   }
 #endif

--- a/KeenClient/KeenClient.m
+++ b/KeenClient/KeenClient.m
@@ -226,9 +226,14 @@ static KIODBStore *dbStore;
     KCLog(@"Disabling Geo Location");
     geoLocationEnabled = NO;
 }
++ (void)enableGeoLocationDefaultRequest {
+    KCLog(@"Enabling Geo Location Request");
+    geoLocationRequestEnabled = YES;
+}
+
 + (void)disableGeoLocationDefaultRequest {
-  KCLog(@"Disabling Geo Location Request");
-  geoLocationRequestEnabled = YES;
+    KCLog(@"Disabling Geo Location Request");
+    geoLocationRequestEnabled = NO;
 }
 
 

--- a/KeenClient/KeenClient.m
+++ b/KeenClient/KeenClient.m
@@ -453,7 +453,7 @@ static KIODBStore *dbStore;
 }
 -(void)locationManager:(CLLocationManager *)manager didFailWithError:(NSError *)error
 {
-  
+  KCLog(@"locationManager-didFailWithError: %@", [error localizedDescription]);
 }
 
 # pragma mark - Add events

--- a/KeenClient/KeenClient.m
+++ b/KeenClient/KeenClient.m
@@ -20,6 +20,7 @@ static BOOL authorizedGeoLocationAlways = NO;
 static BOOL authorizedGeoLocationWhenInUse = NO;
 static BOOL geoLocationEnabled = NO;
 static BOOL loggingEnabled = NO;
+static BOOL geoLocationRequestEnabled = YES;
 static KIODBStore *dbStore;
 
 @interface KeenClient ()
@@ -225,6 +226,11 @@ static KIODBStore *dbStore;
     KCLog(@"Disabling Geo Location");
     geoLocationEnabled = NO;
 }
++ (void)disableGeoLocationDefaultRequest {
+  KCLog(@"Disabling Geo Location Request");
+  geoLocationRequestEnabled = YES;
+}
+
 
 + (void)clearAllEvents {
     [dbStore deleteAllEvents];
@@ -356,17 +362,24 @@ static KIODBStore *dbStore;
     if (geoLocationEnabled == YES) {
         KCLog(@"Geo Location is enabled.");
         // set up the location manager
-        if (self.locationManager == nil) {
-            if ([CLLocationManager locationServicesEnabled]) {
-                self.locationManager = [[CLLocationManager alloc] init];
-                self.locationManager.delegate = self;
-            }
+        if (self.locationManager == nil && [CLLocationManager locationServicesEnabled]) {
+            self.locationManager = [[CLLocationManager alloc] init];
+            self.locationManager.delegate = self;
         }
-        
+      
         // check for iOS 8 and provide appropriate authorization for location services
+      
+        if(self.locationManager != nil)
+        {
+            // If location services are already authorized, then just start monitoring.
+            CLAuthorizationStatus clAuthStatus = [CLLocationManager authorizationStatus];
+            if ([KeenClient isLocationAuthorized:clAuthStatus]) {
+                [self startMonitoringLocation];
+            }
 #if __IPHONE_OS_VERSION_MAX_ALLOWED >= 80000
-        if(self.locationManager != nil) {
-            if([self.locationManager respondsToSelector:@selector(requestAlwaysAuthorization)]) {
+            // Else, try and request permission for that.
+            else if (geoLocationRequestEnabled &&
+                     [self.locationManager respondsToSelector:@selector(requestAlwaysAuthorization)]) {
                 // allow explicit control over the type of authorization
                 if(authorizedGeoLocationAlways) {
                     [self.locationManager requestAlwaysAuthorization];
@@ -379,17 +392,33 @@ static KIODBStore *dbStore;
                     [self.locationManager requestWhenInUseAuthorization];
                 }
             }
-        }
 #endif
-        
-        // if, at this point, the location manager is ready to go, we can start location services
-        if (self.locationManager) {
-            [self.locationManager startUpdatingLocation];
-            KCLog(@"Started location manager.");
         }
+      
     } else {
         KCLog(@"Geo Location is disabled.");
     }
+}
+
+-(void)startMonitoringLocation {
+    if(self.locationManager) {
+        [self.locationManager startUpdatingLocation];
+        KCLog(@"Started location manager.");
+    }
+}
+
++(BOOL)isLocationAuthorized:(CLAuthorizationStatus)status {
+#if TARGET_OS_MAC
+  if (status == kCLAuthorizationStatusAuthorized) {
+    return YES;
+  }
+#else
+  if (status == kCLAuthorizationStatusAuthorizedWhenInUse ||
+      status == kCLAuthorizationStatusAuthorizedAlways) {
+    return YES;
+  }
+#endif
+  return NO;
 }
 
 // Delegate method from the CLLocationManagerDelegate protocol.
@@ -410,6 +439,16 @@ static KIODBStore *dbStore;
     } else {
         KCLog(@"Event wasn't recent enough: %+.2d", (int)fabs(howRecent));
     }
+}
+
+-(void)locationManager:(CLLocationManager *)manager didChangeAuthorizationStatus:(CLAuthorizationStatus)status {
+    if ([KeenClient isLocationAuthorized:status]) {
+        [self startMonitoringLocation];
+    }
+}
+-(void)locationManager:(CLLocationManager *)manager didFailWithError:(NSError *)error
+{
+  
 }
 
 # pragma mark - Add events

--- a/KeenClientTests/KeenClientTests.m
+++ b/KeenClientTests/KeenClientTests.m
@@ -337,6 +337,33 @@
     XCTAssertNil(deserializedLocation, @"No location should have been saved.");
 }
 
+- (void)testGeoLocationRequestDisabled {
+  // now try the same thing but disable geo location
+  KeenClient *client = [KeenClient sharedClientWithProjectID:@"id" andWriteKey:@"wk" andReadKey:@"rk"];
+  KeenClient *clientI = [[KeenClient alloc] initWithProjectID:@"id" andWriteKey:@"wk" andReadKey:@"rk"];
+  
+  [KeenClient disableGeoLocationDefaultRequest];
+  // add an event
+  [client addEvent:@{@"a": @"b"} toEventCollection:@"bar" error:nil];
+  [clientI addEvent:@{@"a": @"b"} toEventCollection:@"bar" error:nil];
+  // now get the stored event
+  
+  // Grab the first event we get back
+  NSDictionary *eventsForCollection = [[[KeenClient getDBStore] getEventsWithMaxAttempts:3 andProjectID:client.projectID] objectForKey:@"bar"];
+  // Grab the first event we get back
+  NSData *eventData = [eventsForCollection objectForKey:[[eventsForCollection allKeys] objectAtIndex:0]];
+  NSError *error = nil;
+  NSDictionary *deserializedDict = [NSJSONSerialization JSONObjectWithData:eventData
+                                                                   options:0
+                                                                     error:&error];
+  
+  NSDictionary *deserializedLocation = deserializedDict[@"keen"][@"location"];
+  XCTAssertNil(deserializedLocation, @"No location should have been saved.");
+  
+  // To properly test this, you want to make sure that this triggers a real location authentication request,
+  // to make sure that it returnings a location.
+}
+
 - (void)testEventWithNonDictionaryKeen {
     KeenClient *client = [KeenClient sharedClientWithProjectID:@"id" andWriteKey:@"wk" andReadKey:@"rk"];
     KeenClient *clientI = [[KeenClient alloc] initWithProjectID:@"id" andWriteKey:@"wk" andReadKey:@"rk"];

--- a/KeenClientTests/KeenClientTests.m
+++ b/KeenClientTests/KeenClientTests.m
@@ -361,7 +361,7 @@
   XCTAssertNil(deserializedLocation, @"No location should have been saved.");
   
   // To properly test this, you want to make sure that this triggers a real location authentication request,
-  // to make sure that it returnings a location.
+  // to make sure that it returns a location.
 }
 
 - (void)testEventWithNonDictionaryKeen {

--- a/README.md
+++ b/README.md
@@ -301,6 +301,17 @@ The block takes in a single string parameter which corresponds to the name of th
 
 Like any good mobile-first service, Keen supports geo localization so you can track where events happened. This is enabled by default. Just use the client as you normally would and your users will be asked to allow geo location services. All events will be automatically tagged with the current location.
 
+If you want to control when you request authentication for location services, you can tell Keen not to request permissions automatically. You do this by calling:
+
+Objective C
+```objc
+[KeenClient disableGeoLocationDefaultRequest];
+```
+Swift
+```Swift
+KeenClient.disableGeoLocationDefaultRequest()
+```
+
 ###### Refreshing Current Location
 
 Every time the app is freshly loaded, the client will automatically ask the device for its current location. It won’t ask again in order to save battery life. You can tell the client to ask the device for location again. Simply call:


### PR DESCRIPTION
In the current version of the Keen SDK, if location is enabled, Keen automatically requests location permissions on startup. I think by default, Keen should not automatically request the location, so the app can make sure to request these permissions at a time that makes sense for their users.

I added a flag which the app can set to make sure that Keen does not request location permissions. This means that:
1) Keen needs to listen to the  `-(void)locationManager:(CLLocationManager *)manager didChangeAuthorizationStatus:(CLAuthorizationStatus)status` delegate method, and when that returns authorized, Keen should update the location.
2) If the app sets this flag, then the app has to be responsible for requesting location permissions at a time that makes sense for the app.