### PR TITLE
Add logging hooks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
 
+## [Unreleased] - Unreleased
+### Added
+- Extensibility hooks for custom logging implementations.
+
 ## [3.5.7] - 2017-03-03
 ### Changed
 - Added SDK platform and version info header to requests.

--- a/KeenClient.xcodeproj/project.pbxproj
+++ b/KeenClient.xcodeproj/project.pbxproj
@@ -77,6 +77,12 @@
 		3EE9A7461C5988F100B7B2D9 /* KIODBStore.h in Headers */ = {isa = PBXBuildFile; fileRef = CA6410D618E37E7C00E53E3C /* KIODBStore.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		3EE9A7471C5988F100B7B2D9 /* KIOQuery.h in Headers */ = {isa = PBXBuildFile; fileRef = 3E63D9EE1AE7356C00E57A17 /* KIOQuery.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		482CB31D1E552F5300FCFACF /* corrupt.sqlite in Resources */ = {isa = PBXBuildFile; fileRef = 482CB31C1E552F5300FCFACF /* corrupt.sqlite */; };
+		481A9B7C1E5690950094B985 /* KeenLogSinkNSLog.h in Headers */ = {isa = PBXBuildFile; fileRef = 481A9B7A1E5690950094B985 /* KeenLogSinkNSLog.h */; };
+		481A9B7D1E5690950094B985 /* KeenLogSinkNSLog.m in Sources */ = {isa = PBXBuildFile; fileRef = 481A9B7B1E5690950094B985 /* KeenLogSinkNSLog.m */; };
+		481A9B7E1E5691270094B985 /* KeenLogSink.h in Headers */ = {isa = PBXBuildFile; fileRef = 481A9B711E5687EA0094B985 /* KeenLogSink.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		48583E071E58CDE2002CFD99 /* KeenLogger.h in Headers */ = {isa = PBXBuildFile; fileRef = 48583E051E58CDE2002CFD99 /* KeenLogger.h */; };
+		48583E081E58CDE2002CFD99 /* KeenLogger.m in Sources */ = {isa = PBXBuildFile; fileRef = 48583E061E58CDE2002CFD99 /* KeenLogger.m */; };
+		48583E0F1E5904FD002CFD99 /* KeenLoggerTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 48583E0E1E5904FD002CFD99 /* KeenLoggerTests.m */; };
 		A51E31241B03C6EF00008248 /* HTTPCodes.h in Headers */ = {isa = PBXBuildFile; fileRef = A51E31221B03C6EF00008248 /* HTTPCodes.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		A51E31251B03C6EF00008248 /* HTTPCodes.m in Sources */ = {isa = PBXBuildFile; fileRef = A51E31231B03C6EF00008248 /* HTTPCodes.m */; };
 		CA6410D818E37E7C00E53E3C /* KIODBStore.h in Headers */ = {isa = PBXBuildFile; fileRef = CA6410D618E37E7C00E53E3C /* KIODBStore.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -176,6 +182,13 @@
 		3EE9A72E1C59873F00B7B2D9 /* KeenClientFramework.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = KeenClientFramework.h; sourceTree = "<group>"; };
 		3EE9A7301C59873F00B7B2D9 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		482CB31C1E552F5300FCFACF /* corrupt.sqlite */ = {isa = PBXFileReference; lastKnownFileType = file; path = corrupt.sqlite; sourceTree = "<group>"; };
+		481A9B711E5687EA0094B985 /* KeenLogSink.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = KeenLogSink.h; sourceTree = "<group>"; };
+		481A9B7A1E5690950094B985 /* KeenLogSinkNSLog.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = KeenLogSinkNSLog.h; sourceTree = "<group>"; };
+		481A9B7B1E5690950094B985 /* KeenLogSinkNSLog.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = KeenLogSinkNSLog.m; sourceTree = "<group>"; };
+		48583E051E58CDE2002CFD99 /* KeenLogger.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = KeenLogger.h; sourceTree = "<group>"; };
+		48583E061E58CDE2002CFD99 /* KeenLogger.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = KeenLogger.m; sourceTree = "<group>"; };
+		48583E0D1E5904FD002CFD99 /* KeenLoggerTests.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = KeenLoggerTests.h; sourceTree = "<group>"; };
+		48583E0E1E5904FD002CFD99 /* KeenLoggerTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = KeenLoggerTests.m; sourceTree = "<group>"; };
 		A51E31221B03C6EF00008248 /* HTTPCodes.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = HTTPCodes.h; sourceTree = "<group>"; };
 		A51E31231B03C6EF00008248 /* HTTPCodes.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = HTTPCodes.m; sourceTree = "<group>"; };
 		A58E0C061AF85F3C00DF2B71 /* KeenSwiftClientExample.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = KeenSwiftClientExample.xcodeproj; path = KeenSwiftClientExample/KeenSwiftClientExample.xcodeproj; sourceTree = "<group>"; };
@@ -315,6 +328,7 @@
 		017EE12314E30C96000F3868 /* KeenClient */ = {
 			isa = PBXGroup;
 			children = (
+				481A9B791E568FC10094B985 /* Logging */,
 				A51E31221B03C6EF00008248 /* HTTPCodes.h */,
 				A51E31231B03C6EF00008248 /* HTTPCodes.m */,
 				017EE12614E30C96000F3868 /* KeenClient.h */,
@@ -352,6 +366,8 @@
 				CA6410E118E39F3A00E53E3C /* KIODBStoreTests.m */,
 				3E63D9F51AE7425000E57A17 /* KIOQueryTests.h */,
 				3E63D9F61AE7425000E57A17 /* KIOQueryTests.m */,
+				48583E0D1E5904FD002CFD99 /* KeenLoggerTests.h */,
+				48583E0E1E5904FD002CFD99 /* KeenLoggerTests.m */,
 			);
 			path = KeenClientTests;
 			sourceTree = "<group>";
@@ -403,6 +419,18 @@
 			path = KeenClientFramework;
 			sourceTree = "<group>";
 		};
+		481A9B791E568FC10094B985 /* Logging */ = {
+			isa = PBXGroup;
+			children = (
+				481A9B711E5687EA0094B985 /* KeenLogSink.h */,
+				481A9B7A1E5690950094B985 /* KeenLogSinkNSLog.h */,
+				481A9B7B1E5690950094B985 /* KeenLogSinkNSLog.m */,
+				48583E051E58CDE2002CFD99 /* KeenLogger.h */,
+				48583E061E58CDE2002CFD99 /* KeenLogger.m */,
+			);
+			name = Logging;
+			sourceTree = "<group>";
+		};
 		A58E0C071AF85F3C00DF2B71 /* Products */ = {
 			isa = PBXGroup;
 			children = (
@@ -439,14 +467,17 @@
 			buildActionMask = 2147483647;
 			files = (
 				0105EE9A14E9A9C80048D871 /* KeenClient.h in Headers */,
+				48583E071E58CDE2002CFD99 /* KeenLogger.h in Headers */,
 				012E8A561672B9A90021F6FA /* KeenProperties.h in Headers */,
 				CA6410D818E37E7C00E53E3C /* KIODBStore.h in Headers */,
 				A51E31241B03C6EF00008248 /* HTTPCodes.h in Headers */,
 				F4D3B6021A0D8EB4000825FE /* KIOReachability.h in Headers */,
 				3E63D9F01AE7356C00E57A17 /* KIOQuery.h in Headers */,
+				481A9B7E1E5691270094B985 /* KeenLogSink.h in Headers */,
 				DE34F6F6197586EE00051390 /* keen_io_sqlite3.h in Headers */,
 				DE34F6F9197586EE00051390 /* keen_io_sqlite3ext.h in Headers */,
 				01BA1B0514E895BC00CF9F84 /* KeenConstants.h in Headers */,
+				481A9B7C1E5690950094B985 /* KeenLogSinkNSLog.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -671,6 +702,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				481A9B7D1E5690950094B985 /* KeenLogSinkNSLog.m in Sources */,
 				3E63D9F11AE7356C00E57A17 /* KIOQuery.m in Sources */,
 				017EE12814E30C96000F3868 /* KeenClient.m in Sources */,
 				01BA1B0614E895BC00CF9F84 /* KeenConstants.m in Sources */,
@@ -678,6 +710,7 @@
 				012E8A571672B9A90021F6FA /* KeenProperties.m in Sources */,
 				F4D3B6061A0D8EB4000825FE /* KIOReachability.m in Sources */,
 				A51E31251B03C6EF00008248 /* HTTPCodes.m in Sources */,
+				48583E081E58CDE2002CFD99 /* KeenLogger.m in Sources */,
 				DE34F6F3197586EE00051390 /* keen_io_sqlite3.c in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -688,6 +721,7 @@
 			files = (
 				CA6410E218E39F3A00E53E3C /* KIODBStoreTests.m in Sources */,
 				3E63D9F71AE7425000E57A17 /* KIOQueryTests.m in Sources */,
+				48583E0F1E5904FD002CFD99 /* KeenLoggerTests.m in Sources */,
 				017EE13F14E30C96000F3868 /* KeenClientTests.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/KeenClient/KIODBStore.m
+++ b/KeenClient/KIODBStore.m
@@ -71,7 +71,7 @@
     __block BOOL wasOpened = NO;
     
     NSString* dbFile = [self getSqliteFullFileName];
-    KCLog(@"%@", dbFile);
+    KCLogInfo(@"%@", dbFile);
     
     // we're going to use a queue for all database operations, so let's create it
     self.dbQueue = dispatch_queue_create("io.keen.sqlite", DISPATCH_QUEUE_SERIAL);
@@ -110,6 +110,7 @@
     }
     
     NSString* dbFile = [self getSqliteFullFileName];
+    KCLogError(@"Deleting corrupt db: %@", dbFile);
     [[NSFileManager defaultManager] removeItemAtPath:dbFile error:nil];
     
     // create new database file
@@ -129,13 +130,13 @@
             return false;
         } else {
             if(![self createTables]) {
-                KCLog(@"Failed to create SQLite table!");
+                KCLogError(@"Failed to create SQLite table!");
                 [self closeDB];
                 return false;
             }
         
             if (![self migrateTable]) {
-                KCLog(@"Failed to migrate SQLite table!");
+                KCLogError(@"Failed to migrate SQLite table!");
                 [self closeDB];
                 return false;
             }
@@ -186,7 +187,7 @@
     __block BOOL wasCreated = NO;
     
     if (!dbIsOpen) {
-        KCLog(@"DB is closed, skipping createTable");
+        KCLogError(@"DB is closed, skipping createTable");
         return wasCreated;
     }
     
@@ -205,14 +206,14 @@
             if (result == SQLITE_CORRUPT) {
                 if (![self deleteAndRecreateCorruptDB])
                 {
-                    KCLog(@"Failed to replace corrupt db while creating events table: %@", [NSString stringWithCString:eventsError encoding:NSUTF8StringEncoding]);
+                    KCLogError(@"Failed to replace corrupt db while creating events table: %@", [NSString stringWithCString:eventsError encoding:NSUTF8StringEncoding]);
                     keen_io_sqlite3_free(eventsError); // Free that error message
                     [self closeDB];
                     break;
                 }
                 // If deleting and recreating the db was successful, continue the loop to create the events table
             } else if (result != SQLITE_OK) {
-                KCLog(@"Failed to create events table: %@", [NSString stringWithCString:eventsError encoding:NSUTF8StringEncoding]);
+                KCLogError(@"Failed to create events table: %@", [NSString stringWithCString:eventsError encoding:NSUTF8StringEncoding]);
                 keen_io_sqlite3_free(eventsError); // Free that error message
                 [self closeDB];
             }
@@ -223,7 +224,7 @@
             char *queriesError;
             NSString *createQueriesTableSQL = [NSString stringWithFormat:@"CREATE TABLE IF NOT EXISTS 'queries' (ID INTEGER PRIMARY KEY AUTOINCREMENT, collection TEXT, projectID TEXT, queryData BLOB, queryType TEXT, attempts INTEGER DEFAULT 0, dateCreated TIMESTAMP DEFAULT CURRENT_TIMESTAMP);"];
             if (keen_io_sqlite3_exec(keen_dbname, [createQueriesTableSQL UTF8String], NULL, NULL, &queriesError) != SQLITE_OK) {
-                KCLog(@"Failed to create queries table: %@", [NSString stringWithCString:queriesError encoding:NSUTF8StringEncoding]);
+                KCLogError(@"Failed to create queries table: %@", [NSString stringWithCString:queriesError encoding:NSUTF8StringEncoding]);
                 keen_io_sqlite3_free(queriesError); // Free that error message
                 [self closeDB];
             } else {
@@ -263,7 +264,7 @@
     char *err;
     NSString *sql = [NSString stringWithFormat:@"PRAGMA user_version = %d;", userVersion];
     if (keen_io_sqlite3_exec(keen_dbname, [sql UTF8String], NULL, NULL, &err) != SQLITE_OK) {
-        KCLog(@"failed to set user_version: %@", [NSString stringWithCString:err encoding:NSUTF8StringEncoding]);
+        KCLogError(@"failed to set user_version: %@", [NSString stringWithCString:err encoding:NSUTF8StringEncoding]);
         keen_io_sqlite3_free(err); // Free that error message
         return NO;
     }
@@ -275,7 +276,7 @@
     __block BOOL wasMigrated = NO;
     
     if (!dbIsOpen) {
-        KCLog(@"DB is closed, skipping migrateTable");
+        KCLogError(@"DB is closed, skipping migrateTable");
         return NO;
     }
     
@@ -283,7 +284,7 @@
     // that we're manipulating in the queue
     dispatch_sync(self.dbQueue, ^{
         int userVersion = [self queryUserVersion];
-        KCLog(@"Preparing to migrate DB, current version: %d", userVersion);
+        KCLogInfo(@"Preparing to migrate DB, current version: %d", userVersion);
         wasMigrated = [self migrateFromVersion:userVersion];
     });
     
@@ -296,7 +297,7 @@
     for(int i = 0; i < 1000; i++) {
         if(![self beginTransaction]) {
             // deal with error?
-            KCLog(@"Migration failed to begin a transaction with userVersion = %d.", userVersion);
+            KCLogError(@"Migration failed to begin a transaction with userVersion = %d.", userVersion);
             return NO;
         }
         
@@ -304,7 +305,7 @@
         if (migrationResult == 0) {
             // we didn't migrate anything, because we're current.
             if (![self endTransaction]) {
-                KCLog(@"Migration failed to end a transaction with userVersion = %d.", userVersion);
+                KCLogError(@"Migration failed to end a transaction with userVersion = %d.", userVersion);
                 return NO;
             }
             return YES;
@@ -313,7 +314,7 @@
         if (migrationResult < 0) {
             // error
             if (![self rollbackTransaction]) {
-                KCLog(@"Migration failed to rollback a transaction with userVersion = %d.", userVersion);
+                KCLogError(@"Migration failed to rollback a transaction with userVersion = %d.", userVersion);
                 // yeesh, couldn't rollback
             }
             return NO;
@@ -321,9 +322,9 @@
         
         // we migrated, so increment PRAGMA user_version
         if (![self setUserVersion:userVersion+1]) {
-            KCLog(@"Migration failed to set the user_version to %d.", userVersion);
+            KCLogError(@"Migration failed to set the user_version to %d.", userVersion);
             if (![self rollbackTransaction]) {
-                KCLog(@"Migration failed to rollback a transaction after failing to set user_version (with userVersion = %d).", userVersion);
+                KCLogError(@"Migration failed to rollback a transaction after failing to set user_version (with userVersion = %d).", userVersion);
                 // whoa, double bad news
             }
             return NO;
@@ -331,7 +332,7 @@
         
         // ok, let's commit this step
         if (![self commitTransaction]) {
-            KCLog(@"Migration failed to commit a transaction with userVersion = %d.", userVersion);
+            KCLogError(@"Migration failed to commit a transaction with userVersion = %d.", userVersion);
             return NO;
         }
         
@@ -340,7 +341,7 @@
         // there might be more migrations, so we loop around again
     }
     
-    KCLog(@"Migration loop maxed out after 1000 iterations. This is almost certainly a bug. Version %d", [self queryUserVersion]);
+    KCLogError(@"Migration loop maxed out after 1000 iterations. This is almost certainly a bug. Version %d", [self queryUserVersion]);
     
     return NO;
 }
@@ -357,7 +358,7 @@
     } else if (forVersion == 1) {
         NSString *sql = @"ALTER TABLE events ADD COLUMN attempts INTEGER DEFAULT 0;";
         if (keen_io_sqlite3_exec(keen_dbname, [sql UTF8String], NULL, NULL, &err) != SQLITE_OK) {
-            KCLog(@"Failed to add attempts column: %@", [NSString stringWithCString:err encoding:NSUTF8StringEncoding]);
+            KCLogError(@"Failed to add attempts column: %@", [NSString stringWithCString:err encoding:NSUTF8StringEncoding]);
             keen_io_sqlite3_free(err); // Free that error message
             return -1;
         }
@@ -386,7 +387,7 @@
     char *err;
     NSString *sql = sqlTransaction;
     if (keen_io_sqlite3_exec(keen_dbname, [sql UTF8String], NULL, NULL, &err) != SQLITE_OK) {
-        KCLog(@"failed to do transaction:%@, with error: %@", sqlTransaction, [NSString stringWithCString:err encoding:NSUTF8StringEncoding]);
+        KCLogError(@"failed to do transaction:%@, with error: %@", sqlTransaction, [NSString stringWithCString:err encoding:NSUTF8StringEncoding]);
         keen_io_sqlite3_free(err); // Free that error message
         return NO;
     }
@@ -969,7 +970,7 @@
 
 - (BOOL)checkOpenDB:(NSString *)failureMessage {
     if(![self openAndInitDB]) {
-        KCLog(@"%@", failureMessage);
+        KCLogError(@"%@", failureMessage);
         return false;
     }
     
@@ -1057,14 +1058,15 @@
 }
 
 - (void)handleSQLiteFailure:(NSString *) msg {
-    KCLog(@"Failed to %@: %@",
+    KCLogError(@"Failed to %@: %@",
           msg, [NSString stringWithCString:keen_io_sqlite3_errmsg(keen_dbname) encoding:NSUTF8StringEncoding]);
     int result = keen_io_sqlite3_errcode(keen_dbname);
     [self closeDB];
     if (SQLITE_CORRUPT == result)
     {
-        KCLog(@"Deleting corrupt DB file.");
-        [[NSFileManager defaultManager] removeItemAtPath:[self getSqliteFullFileName] error:nil];
+        NSString* dbFile = [self getSqliteFullFileName];
+        KCLogError(@"Deleting corrupt db: %@", dbFile);
+        [[NSFileManager defaultManager] removeItemAtPath:dbFile error:nil];
     }
 }
 

--- a/KeenClient/KeenClient.h
+++ b/KeenClient/KeenClient.h
@@ -376,7 +376,8 @@ typedef NSDictionary* (^KeenGlobalPropertiesBlock)(NSString *eventCollection);
 /**
  Add a log sink
  */
-+ (void)addLogSink:(id<KeenLogSink>)sink;
++ (void)addLogSink:(id<KeenLogSink>)logSink
+NS_SWIFT_NAME(addLogSink(_:));
 
 /**
  Remove a log sink
@@ -393,10 +394,10 @@ typedef NSDictionary* (^KeenGlobalPropertiesBlock)(NSString *eventCollection);
 + (void)logMessageWithLevel:(KeenLogLevel)level andMessage:(NSString*)message;
 
 // defines the KCLog macro
-#define KCLogError(message, ...)    { [KeenClient logMessageWithLevel:KLL_ERROR andMessage:[NSString stringWithFormat:message, ##__VA_ARGS__]]; }
-#define KCLogWarn(message, ...)     { [KeenClient logMessageWithLevel:KLL_WARNING andMessage:[NSString stringWithFormat:message, ##__VA_ARGS__]]; }
-#define KCLogInfo(message, ...)     { [KeenClient logMessageWithLevel:KLL_INFO andMessage:[NSString stringWithFormat:message, ##__VA_ARGS__]]; }
-#define KCLogVerbose(message, ...)  { [KeenClient logMessageWithLevel:KLL_VERBOSE andMessage:[NSString stringWithFormat:message, ##__VA_ARGS__]]; }
+#define KCLogError(message, ...)    { [KeenClient logMessageWithLevel:KeenLogLevelError andMessage:[NSString stringWithFormat:message, ##__VA_ARGS__]]; }
+#define KCLogWarn(message, ...)     { [KeenClient logMessageWithLevel:KeenLogLevelWarning andMessage:[NSString stringWithFormat:message, ##__VA_ARGS__]]; }
+#define KCLogInfo(message, ...)     { [KeenClient logMessageWithLevel:KeenLogLevelInfo andMessage:[NSString stringWithFormat:message, ##__VA_ARGS__]]; }
+#define KCLogVerbose(message, ...)  { [KeenClient logMessageWithLevel:KeenLogLevelVerbose andMessage:[NSString stringWithFormat:message, ##__VA_ARGS__]]; }
 
 
 @end

--- a/KeenClient/KeenClient.h
+++ b/KeenClient/KeenClient.h
@@ -374,6 +374,16 @@ typedef NSDictionary* (^KeenGlobalPropertiesBlock)(NSString *eventCollection);
 + (BOOL)isLoggingEnabled;
 
 /**
+ Enable or disable logging to NSLog
+ */
++ (void)setIsNSLogEnabled:(BOOL)isNSLogEnabled;
+
+/**
+ Whether or not NSLog logging is enabled
+ */
++ (BOOL)isNSLogEnabled;
+
+/**
  Add a log sink
  */
 + (void)addLogSink:(id<KeenLogSink>)logSink

--- a/KeenClient/KeenClient.h
+++ b/KeenClient/KeenClient.h
@@ -386,7 +386,7 @@ NS_SWIFT_NAME(addLogSink(_:));
 
 /**
  Set the verbosity of logging that will be sent to the sinks.
- The default log level is KLL_ERROR.
+ The default log level is KeenLogLevelError.
  */
 + (void)setLogLevel:(KeenLogLevel)level;
 

--- a/KeenClient/KeenClient.h
+++ b/KeenClient/KeenClient.h
@@ -11,6 +11,7 @@
 #import "KIODBStore.h"
 #import "KIOQuery.h"
 #import "KeenProperties.h"
+#import "KeenLogger.h"
 
 // defines a type for the block we'll use with our global properties
 typedef NSDictionary* (^KeenGlobalPropertiesBlock)(NSString *eventCollection);
@@ -182,22 +183,6 @@ typedef NSDictionary* (^KeenGlobalPropertiesBlock)(NSString *eventCollection);
  */
 + (void)disableGeoLocationDefaultRequest;
 
-/**
- Call this to disable debug logging. It's disabled by default.
- */
-+ (void)disableLogging;
-
-/**
- Call this to enable debug logging.
- */
-+ (void)enableLogging;
-
-/**
- Returns whether or not logging is currently enabled.
- 
- @return true if logging is enabled, false if disabled.
- */
-+ (BOOL)isLoggingEnabled;
 
 
 /**
@@ -364,7 +349,54 @@ typedef NSDictionary* (^KeenGlobalPropertiesBlock)(NSString *eventCollection);
  */
 + (void)clearAllQueries;
 
+
+/**
+ KeenClient logging
+ */
+
+/**
+ Call this to disable debug logging. It's disabled by default.
+ */
++ (void)disableLogging;
+
+/**
+ Call this to enable debug logging. If no log sinks have been added
+ prior to this call, a default log sink will be set up that logs
+ to NSLog.
+ */
++ (void)enableLogging;
+
+/**
+ Returns whether or not logging is currently enabled.
+ 
+ @return true if logging is enabled, false if disabled.
+ */
++ (BOOL)isLoggingEnabled;
+
+/**
+ Add a log sink
+ */
++ (void)addLogSink:(id<KeenLogSink>)sink;
+
+/**
+ Remove a log sink
+ */
++ (void)removeLogSink:(id<KeenLogSink>)sink;
+
+/**
+ Set the verbosity of logging that will be sent to the sinks.
+ The default log level is KLL_ERROR.
+ */
++ (void)setLogLevel:(KeenLogLevel)level;
+
+
++ (void)logMessageWithLevel:(KeenLogLevel)level andMessage:(NSString*)message;
+
 // defines the KCLog macro
-#define KCLog(message, ...) { if([KeenClient isLoggingEnabled]) { NSLog(message, ##__VA_ARGS__); } }
+#define KCLogError(message, ...)    { [KeenClient logMessageWithLevel:KLL_ERROR andMessage:[NSString stringWithFormat:message, ##__VA_ARGS__]]; }
+#define KCLogWarn(message, ...)     { [KeenClient logMessageWithLevel:KLL_WARNING andMessage:[NSString stringWithFormat:message, ##__VA_ARGS__]]; }
+#define KCLogInfo(message, ...)     { [KeenClient logMessageWithLevel:KLL_INFO andMessage:[NSString stringWithFormat:message, ##__VA_ARGS__]]; }
+#define KCLogVerbose(message, ...)  { [KeenClient logMessageWithLevel:KLL_VERBOSE andMessage:[NSString stringWithFormat:message, ##__VA_ARGS__]]; }
+
 
 @end

--- a/KeenClient/KeenClient.m
+++ b/KeenClient/KeenClient.m
@@ -213,6 +213,14 @@ static KIODBStore *dbStore;
     return [[KeenLogger sharedLogger] isLoggingEnabled];
 }
 
++ (void)setIsNSLogEnabled:(BOOL)isNSLogEnabled {
+    [[KeenLogger sharedLogger] setIsNSLogEnabled:isNSLogEnabled];
+}
+
++ (BOOL)isNSLogEnabled {
+    return [[KeenLogger sharedLogger] isNSLogEnabled];
+}
+
 + (void)addLogSink:(id<KeenLogSink>)sink {
     [[KeenLogger sharedLogger] addLogSink:sink];
 }

--- a/KeenClient/KeenLogSink.h
+++ b/KeenClient/KeenLogSink.h
@@ -1,0 +1,37 @@
+//
+//  KeenLogger.h
+//  KeenClient
+//
+//  Created by Brian Baumhover on 2/16/17.
+//  Copyright © 2017 Keen Labs. All rights reserved.
+//
+
+// A given log level will include all
+// messages in lower verbosity levels.
+// For example, if the log level is set
+// to KLL_WARN, messages will log level
+// of both KLL_WARN and KLL_ERROR will
+// be logged.
+typedef enum {
+    KLL_ERROR = 1,
+    KLL_WARNING = 2,
+    KLL_INFO = 3,
+    KLL_VERBOSE = 4
+} KeenLogLevel;
+
+//
+// If you want logs from KeenClient, implement this protocol, provide it to KeenClient via addLogSink,
+// then set the desired log level and enable logging.
+//
+@protocol KeenLogSink
+
+- (void)logMessageWithLevel:(KeenLogLevel)msgLevel andMessage:(NSString*)message;
+
+// Even after calling KeenClient removeLogSink, a sink will
+// receive messages that had already been queued before the call
+// to removeLogSink. This callback gives the logger an opportunity
+// to do any processing or flushing it needs to do once it
+// has actually been removed from the list of loggers.
+- (void)onRemoved;
+
+@end

--- a/KeenClient/KeenLogSink.h
+++ b/KeenClient/KeenLogSink.h
@@ -12,12 +12,12 @@
 // to KLL_WARN, messages will log level
 // of both KLL_WARN and KLL_ERROR will
 // be logged.
-typedef enum {
-    KLL_ERROR = 1,
-    KLL_WARNING = 2,
-    KLL_INFO = 3,
-    KLL_VERBOSE = 4
-} KeenLogLevel;
+typedef NS_ENUM(NSInteger, KeenLogLevel) {
+    KeenLogLevelError = 1,
+    KeenLogLevelWarning = 2,
+    KeenLogLevelInfo = 3,
+    KeenLogLevelVerbose = 4
+};
 
 //
 // If you want logs from KeenClient, implement this protocol, provide it to KeenClient via addLogSink,

--- a/KeenClient/KeenLogSink.h
+++ b/KeenClient/KeenLogSink.h
@@ -1,5 +1,5 @@
 //
-//  KeenLogger.h
+//  KeenLogSink.h
 //  KeenClient
 //
 //  Created by Brian Baumhover on 2/16/17.
@@ -13,10 +13,10 @@
 // of both KLL_WARN and KeenLogLevelError will
 // be logged.
 typedef NS_ENUM(NSInteger, KeenLogLevel) {
-    KeenLogLevelError = 1,
-    KeenLogLevelWarning = 2,
-    KeenLogLevelInfo = 3,
-    KeenLogLevelVerbose = 4
+    KeenLogLevelError = 0,
+    KeenLogLevelWarning = 1,
+    KeenLogLevelInfo = 2,
+    KeenLogLevelVerbose = 3
 };
 
 //

--- a/KeenClient/KeenLogSink.h
+++ b/KeenClient/KeenLogSink.h
@@ -10,7 +10,7 @@
 // messages in lower verbosity levels.
 // For example, if the log level is set
 // to KLL_WARN, messages will log level
-// of both KLL_WARN and KLL_ERROR will
+// of both KLL_WARN and KeenLogLevelError will
 // be logged.
 typedef NS_ENUM(NSInteger, KeenLogLevel) {
     KeenLogLevelError = 1,

--- a/KeenClient/KeenLogSinkNSLog.h
+++ b/KeenClient/KeenLogSinkNSLog.h
@@ -1,0 +1,14 @@
+//
+//  KeenLogSinkNSLog.h
+//  KeenClient
+//
+//  Created by Brian Baumhover on 2/16/17.
+//  Copyright © 2017 Keen Labs. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+#import "KeenLogSink.h"
+
+@interface KeenLogSinkNSLog : NSObject<KeenLogSink>
+
+@end

--- a/KeenClient/KeenLogSinkNSLog.m
+++ b/KeenClient/KeenLogSinkNSLog.m
@@ -13,16 +13,16 @@
 - (void)logMessageWithLevel:(KeenLogLevel)msgLevel andMessage:(NSString*)message {
     NSString* logPrefix;
     switch (msgLevel) {
-        case KLL_ERROR:
+        case KeenLogLevelError:
             logPrefix = @"E:";
             break;
-        case KLL_WARNING:
+        case KeenLogLevelWarning:
             logPrefix = @"W:";
             break;
-        case KLL_INFO:
+        case KeenLogLevelInfo:
             logPrefix = @"I:";
             break;
-        case KLL_VERBOSE:
+        case KeenLogLevelVerbose:
             logPrefix = @"V:";
             break;
     }

--- a/KeenClient/KeenLogSinkNSLog.m
+++ b/KeenClient/KeenLogSinkNSLog.m
@@ -1,0 +1,36 @@
+//
+//  KeenLogSinkNSLog.m
+//  KeenClient
+//
+//  Created by Brian Baumhover on 2/16/17.
+//  Copyright © 2017 Keen Labs. All rights reserved.
+//
+
+#import "KeenLogSinkNSLog.h"
+
+@implementation KeenLogSinkNSLog
+
+- (void)logMessageWithLevel:(KeenLogLevel)msgLevel andMessage:(NSString*)message {
+    NSString* logPrefix;
+    switch (msgLevel) {
+        case KLL_ERROR:
+            logPrefix = @"E:";
+            break;
+        case KLL_WARNING:
+            logPrefix = @"W:";
+            break;
+        case KLL_INFO:
+            logPrefix = @"I:";
+            break;
+        case KLL_VERBOSE:
+            logPrefix = @"V:";
+            break;
+    }
+    NSLog(@"%@%@", logPrefix, message);
+}
+
+- (void)onRemoved {
+    // do nothing
+}
+
+@end

--- a/KeenClient/KeenLogger.h
+++ b/KeenClient/KeenLogger.h
@@ -1,0 +1,57 @@
+//
+//  KeenLogger.h
+//  KeenClient
+//
+//  Created by Brian Baumhover on 2/18/17.
+//  Copyright © 2017 Keen Labs. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+#import "KeenLogSink.h"
+
+
+@interface KeenLogger : NSObject
+
+/**
+ Get the shared logger instance.
+ */
++ (KeenLogger*)sharedLogger;
+
+/**
+ Call this to disable debug logging. It's disabled by default.
+ */
+- (void)disableLogging;
+
+/**
+ Call this to enable debug logging with a default NSLog logger
+ */
+- (void)enableLogging;
+
+/**
+ Returns whether or not logging is currently enabled.
+ 
+ @return true if logging is enabled, false if disabled.
+ */
+- (BOOL)isLoggingEnabled;
+
+/*
+ Set the level of logging to dispatch to all sinks.
+ */
+- (void)setLogLevel:(KeenLogLevel)logLevel;
+
+/**
+ Add a log sink
+ */
+- (void)addLogSink:(id<KeenLogSink>)logger;
+
+/**
+ Remove a log sink
+ */
+- (void)removeLogSink:(id<KeenLogSink>)logger;
+
+/**
+ Log a message using registered loggers
+ */
+- (void)logMessageWithLevel:(KeenLogLevel)msgLevel andMessage:(NSString*)message;
+
+@end

--- a/KeenClient/KeenLogger.h
+++ b/KeenClient/KeenLogger.h
@@ -23,13 +23,24 @@
 - (void)disableLogging;
 
 /**
- Call this to enable debug logging with a default NSLog logger
+ Call this to enable debug logging. If no log sinks have been added,
+ a default NSLog logger will automatically be added.
  */
 - (void)enableLogging;
 
 /**
+ Enable or disable logging to NSLog
+ */
+- (void)setIsNSLogEnabled:(BOOL)isNSLogEnabled;
+
+/**
+ Whether or not NSLog logging is enabled
+ */
+- (BOOL)isNSLogEnabled;
+
+/**
  Returns whether or not logging is currently enabled.
- 
+
  @return true if logging is enabled, false if disabled.
  */
 - (BOOL)isLoggingEnabled;

--- a/KeenClient/KeenLogger.m
+++ b/KeenClient/KeenLogger.m
@@ -11,16 +11,18 @@
 
 @implementation KeenLogger
 
-BOOL logSinksEnabled;
-_Atomic(BOOL) loggingEnabled;
-KeenLogLevel logLevel;
-NSMutableArray *logSinks;
-dispatch_queue_t loggerQueue;
+BOOL _areLogSinksEnabled;
+_Atomic(BOOL) _isLoggingEnabled;
+_Atomic(BOOL) _isNSLogEnabled;
+KeenLogLevel _logLevel;
+NSMutableArray *_logSinks;
+dispatch_queue_t _loggerQueue;
+KeenLogSinkNSLog* _logSinkNSLog;
 
 
 + (KeenLogger*)sharedLogger {
-    static KeenLogger* logger;
-    
+    static KeenLogger* s_logger;
+
     // This black magic ensures this block
     // is dispatched only once over the lifetime
     // of the program. It's nice because
@@ -30,106 +32,138 @@ dispatch_queue_t loggerQueue;
     // for the block to complete.
     static dispatch_once_t predicate = {0};
     dispatch_once(&predicate, ^{
-        logger = [[KeenLogger alloc] init];
+        s_logger = [[KeenLogger alloc] init];
     });
-    
-    return logger;
+
+    return s_logger;
 }
 
 
 - (KeenLogger*)init {
     self = [super init];
-    
+
     if (nil != self) {
         // By default we won't enable logging.
-        logSinksEnabled = NO;
-        loggingEnabled = NO;
+        _areLogSinksEnabled = NO;
+        _isLoggingEnabled = NO;
         // Default log level is error so we aren't noisy
-        logLevel = KeenLogLevelError;
+        _logLevel = KeenLogLevelError;
         // Create a serial queue for logging messages and manipulating loggers.
         // This will ensure that messages from different threads
         // don't get mixed together, and we don't have to worry
         // about concurrent access when adding and removing loggers
         // since those operations will be dispatched to this queue as well.
-        loggerQueue = dispatch_queue_create("io.keen.logger", DISPATCH_QUEUE_SERIAL);
-        if (NULL == loggerQueue) {
+        _loggerQueue = dispatch_queue_create("io.keen.logger", DISPATCH_QUEUE_SERIAL);
+        if (NULL == _loggerQueue) {
             // Failed to allocate the queue
             self = nil;
         }
-        
-        logSinks = [[NSMutableArray alloc] init];
-        if (nil == logSinks) {
+
+        _logSinks = [[NSMutableArray alloc] init];
+        if (nil == _logSinks) {
             // Failed to allocate the array
             self = nil;
         }
+
+        // Enable NSLog by default
+        [self setIsNSLogEnabled:YES];
     }
-    
+
     return self;
 }
 
 
 - (void)disableLogging {
-    loggingEnabled = NO;
-    dispatch_async(loggerQueue, ^() {
+    _isLoggingEnabled = NO;
+    dispatch_async(_loggerQueue, ^() {
         // Disable actual logging to sinks
         // on the queue so anything that
         // has already been logged but hasn't
         // been sinked will have the
         // opportunity to do so.
-        logSinksEnabled = NO;
+        _areLogSinksEnabled = NO;
     });
 }
 
 
 - (void)enableLogging {
-    loggingEnabled = YES;
-    dispatch_async(loggerQueue, ^() {
-        if ([logSinks count] == 0) {
-            // Allocate a default logger if none have
-            // been provided.
-            [logSinks addObject:[[KeenLogSinkNSLog alloc] init]];
-        }
-        logSinksEnabled = YES;
+    _isLoggingEnabled = YES;
+    dispatch_async(_loggerQueue, ^() {
+        _areLogSinksEnabled = YES;
     });
 }
 
 
+- (void)setIsNSLogEnabled:(BOOL)isNSLogEnabled {
+    _isNSLogEnabled = isNSLogEnabled;
+    dispatch_async(_loggerQueue, ^() {
+        if (isNSLogEnabled) {
+            if (nil == _logSinkNSLog) {
+                // Create the NSLog logger
+                _logSinkNSLog = [[KeenLogSinkNSLog alloc] init];
+            }
+
+            if (!([_logSinks containsObject:_logSinkNSLog])) {
+                // Add the NSLog logger to the list of loggers if it hasn't already been added
+                [_logSinks addObject:_logSinkNSLog];
+            }
+        } else {
+            // Remove the logger if it has been added
+            if (nil != _logSinkNSLog) {
+                if ([_logSinks containsObject:_logSinkNSLog]) {
+                    [_logSinks removeObject:_logSinkNSLog];
+                }
+
+                _logSinkNSLog = nil;
+            }
+        }
+    });
+}
+
+
+- (BOOL)isNSLogEnabled {
+    return _isNSLogEnabled;
+}
+
+
 - (BOOL)isLoggingEnabled {
-    return loggingEnabled;
+    return _isLoggingEnabled;
 }
 
 
 - (void)setLogLevel:(KeenLogLevel)level {
-    dispatch_async(loggerQueue, ^() {
-        logLevel = level;
+    dispatch_async(_loggerQueue, ^() {
+        _logLevel = level;
     });
 }
 
 
 - (void)addLogSink:(id<KeenLogSink>)sink {
-    dispatch_async(loggerQueue, ^() {
-        [logSinks addObject:sink];
+    dispatch_async(_loggerQueue, ^() {
+        [_logSinks addObject:sink];
     });
 }
 
 
 - (void)removeLogSink:(id<KeenLogSink>)sink {
-    dispatch_async(loggerQueue, ^() {
-        [logSinks removeObject:sink];
+    dispatch_async(_loggerQueue, ^() {
+        [_logSinks removeObject:sink];
         [sink onRemoved];
     });
 }
 
 
 - (void)logMessageWithLevel:(KeenLogLevel)msgLevel andMessage:(NSString*)message {
-    dispatch_async(loggerQueue, ^() {
-        if (logSinksEnabled &&
-            msgLevel <= logLevel) {
-            for (id<KeenLogSink> sink in logSinks) {
-                [sink logMessageWithLevel:msgLevel andMessage:message];
+    if (YES == _isLoggingEnabled) { // Only bother to dispatch if logging is currently enabled
+        dispatch_async(_loggerQueue, ^() {
+            if (_areLogSinksEnabled &&
+                msgLevel <= _logLevel) {
+                for (id<KeenLogSink> sink in _logSinks) {
+                    [sink logMessageWithLevel:msgLevel andMessage:message];
+                }
             }
-        }
-    });
+        });
+    }
 }
 
 

--- a/KeenClient/KeenLogger.m
+++ b/KeenClient/KeenLogger.m
@@ -1,0 +1,136 @@
+//
+//  KeenLogger.m
+//  KeenClient
+//
+//  Created by Brian Baumhover on 2/18/17.
+//  Copyright © 2017 Keen Labs. All rights reserved.
+//
+
+#import "KeenLogger.h"
+#import "KeenLogSinkNSLog.h"
+
+@implementation KeenLogger
+
+BOOL logSinksEnabled;
+_Atomic(BOOL) loggingEnabled;
+KeenLogLevel logLevel;
+NSMutableArray *logSinks;
+dispatch_queue_t loggerQueue;
+
+
++ (KeenLogger*)sharedLogger {
+    static KeenLogger* logger;
+    
+    // This black magic ensures this block
+    // is dispatched only once over the lifetime
+    // of the program. It's nice because
+    // this works even when there's a race
+    // between threads to create the object,
+    // as both threads will wait synchronously
+    // for the block to complete.
+    static dispatch_once_t predicate = {0};
+    dispatch_once(&predicate, ^{
+        logger = [[KeenLogger alloc] init];
+    });
+    
+    return logger;
+}
+
+
+- (KeenLogger*)init {
+    self = [super init];
+    
+    if (nil != self) {
+        // By default we won't enable logging.
+        logSinksEnabled = NO;
+        loggingEnabled = NO;
+        // Default log level is error so we aren't noisy
+        logLevel = KLL_ERROR;
+        // Create a serial queue for logging messages and manipulating loggers.
+        // This will ensure that messages from different threads
+        // don't get mixed together, and we don't have to worry
+        // about concurrent access when adding and removing loggers
+        // since those operations will be dispatched to this queue as well.
+        loggerQueue = dispatch_queue_create("io.keen.logger", DISPATCH_QUEUE_SERIAL);
+        if (NULL == loggerQueue) {
+            // Failed to allocate the queue
+            self = nil;
+        }
+        
+        logSinks = [[NSMutableArray alloc] init];
+        if (nil == logSinks) {
+            // Failed to allocate the array
+            self = nil;
+        }
+    }
+    
+    return self;
+}
+
+
+- (void)disableLogging {
+    loggingEnabled = NO;
+    dispatch_async(loggerQueue, ^() {
+        // Disable actual logging to sinks
+        // on the queue so anything that
+        // has already been logged but hasn't
+        // been sinked will have the
+        // opportunity to do so.
+        logSinksEnabled = NO;
+    });
+}
+
+
+- (void)enableLogging {
+    loggingEnabled = YES;
+    dispatch_async(loggerQueue, ^() {
+        if ([logSinks count] == 0) {
+            // Allocate a default logger if none have
+            // been provided.
+            [logSinks addObject:[[KeenLogSinkNSLog alloc] init]];
+        }
+        logSinksEnabled = YES;
+    });
+}
+
+
+- (BOOL)isLoggingEnabled {
+    return loggingEnabled;
+}
+
+
+- (void)setLogLevel:(KeenLogLevel)level {
+    dispatch_async(loggerQueue, ^() {
+        logLevel = level;
+    });
+}
+
+
+- (void)addLogSink:(id<KeenLogSink>)sink {
+    dispatch_async(loggerQueue, ^() {
+        [logSinks addObject:sink];
+    });
+}
+
+
+- (void)removeLogSink:(id<KeenLogSink>)sink {
+    dispatch_async(loggerQueue, ^() {
+        [logSinks removeObject:sink];
+        [sink onRemoved];
+    });
+}
+
+
+- (void)logMessageWithLevel:(KeenLogLevel)msgLevel andMessage:(NSString*)message {
+    dispatch_async(loggerQueue, ^() {
+        if (logSinksEnabled &&
+            msgLevel <= logLevel) {
+            for (id<KeenLogSink> sink in logSinks) {
+                [sink logMessageWithLevel:msgLevel andMessage:message];
+            }
+        }
+    });
+}
+
+
+@end

--- a/KeenClient/KeenLogger.m
+++ b/KeenClient/KeenLogger.m
@@ -45,7 +45,7 @@ dispatch_queue_t loggerQueue;
         logSinksEnabled = NO;
         loggingEnabled = NO;
         // Default log level is error so we aren't noisy
-        logLevel = KLL_ERROR;
+        logLevel = KeenLogLevelError;
         // Create a serial queue for logging messages and manipulating loggers.
         // This will ensure that messages from different threads
         // don't get mixed together, and we don't have to worry

--- a/KeenClientExample/KeenClientExample.xcodeproj/project.pbxproj
+++ b/KeenClientExample/KeenClientExample.xcodeproj/project.pbxproj
@@ -50,8 +50,8 @@
 		012E8A5F1672C30C0021F6FA /* CoreLocation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreLocation.framework; path = System/Library/Frameworks/CoreLocation.framework; sourceTree = SDKROOT; };
 		015D307E1822DE7D00F8735B /* Default-568h@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "Default-568h@2x.png"; sourceTree = "<group>"; };
 		01F90AF514F36C2800DD3DE2 /* KeenClient.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = KeenClient.h; path = ../KeenClient/KeenClient.h; sourceTree = "<group>"; };
-		3E0EC09D1B11701B00195A42 /* third.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; name = third.png; path = "../../../../Github/KeenClient-iOS/KeenClientExample/KeenClientExample/third.png"; sourceTree = "<group>"; };
-		3E0EC09E1B11701B00195A42 /* third@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; name = "third@2x.png"; path = "../../../../Github/KeenClient-iOS/KeenClientExample/KeenClientExample/third@2x.png"; sourceTree = "<group>"; };
+		3E0EC09D1B11701B00195A42 /* third.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = third.png; sourceTree = "<group>"; };
+		3E0EC09E1B11701B00195A42 /* third@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "third@2x.png"; sourceTree = "<group>"; };
 		3E0EC0A71B11740900195A42 /* ThirdViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ThirdViewController.h; sourceTree = "<group>"; };
 		3E0EC0A81B11740900195A42 /* ThirdViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ThirdViewController.m; sourceTree = "<group>"; };
 		3E0EC0A91B11740900195A42 /* ThirdViewController.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = ThirdViewController.xib; sourceTree = "<group>"; };

--- a/KeenClientExample/KeenClientExample/AppDelegate.m
+++ b/KeenClientExample/KeenClientExample/AppDelegate.m
@@ -22,6 +22,8 @@
 - (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions
 {
     [KeenClient enableLogging];
+    [KeenClient setIsNSLogEnabled:YES];
+    [KeenClient setLogLevel:KeenLogLevelVerbose];
     KeenClient *client = [KeenClient sharedClientWithProjectID:@"pi" andWriteKey:@"wk" andReadKey:@"rk"];
     client.globalPropertiesBlock = ^NSDictionary *(NSString *eventCollection) {
         return @{ @"GLOBALS": @"YEAH WHAT"};

--- a/KeenClientTests/KIOQueryTests.m
+++ b/KeenClientTests/KIOQueryTests.m
@@ -42,7 +42,7 @@
     
     NSData *data = [query convertQueryToData];
     
-    KCLog(@"Error when writing event to file: %@", data);
+    KCLogError(@"Error when writing event to file: %@", data);
     
     XCTAssertNotNil(data, @"data is not null");
 }

--- a/KeenClientTests/KeenClientTests.m
+++ b/KeenClientTests/KeenClientTests.m
@@ -54,7 +54,7 @@
     [[KeenClient sharedClient] setProjectID:nil];
     [[KeenClient sharedClient] setWriteKey:nil];
     [[KeenClient sharedClient] setReadKey:nil];
-    [KeenClient setLogLevel:KLL_VERBOSE];
+    [KeenClient setLogLevel:KeenLogLevelVerbose];
     [KeenClient enableLogging];
     [[KeenClient sharedClient] setGlobalPropertiesBlock:nil];
     [[KeenClient sharedClient] setGlobalPropertiesDictionary:nil];

--- a/KeenClientTests/KeenClientTests.m
+++ b/KeenClientTests/KeenClientTests.m
@@ -54,6 +54,7 @@
     [[KeenClient sharedClient] setProjectID:nil];
     [[KeenClient sharedClient] setWriteKey:nil];
     [[KeenClient sharedClient] setReadKey:nil];
+    [KeenClient setLogLevel:KLL_VERBOSE];
     [KeenClient enableLogging];
     [[KeenClient sharedClient] setGlobalPropertiesBlock:nil];
     [[KeenClient sharedClient] setGlobalPropertiesDictionary:nil];
@@ -1591,9 +1592,9 @@
     KIOQuery *query = [[KIOQuery alloc] initWithQuery:@"count" andPropertiesDictionary:@{}];
 
     [mock runQuery:query completionHandler:^(NSData *queryResponseData, NSURLResponse *response, NSError *error) {
-        KCLog(@"error: %@", error);
-        KCLog(@"response: %@", response);
-
+        KCLogInfo(@"error: %@", error);
+        KCLogInfo(@"response: %@", response);
+        
         XCTAssertNil(error);
 
         NSHTTPURLResponse *httpResponse = (NSHTTPURLResponse*) response;
@@ -1603,9 +1604,9 @@
                                             JSONObjectWithData:queryResponseData
                                             options:kNilOptions
                                             error:&error];
-
-        KCLog(@"response: %@", responseDictionary);
-
+        
+        KCLogInfo(@"response: %@", responseDictionary);
+        
         NSNumber *result = [responseDictionary objectForKey:@"result"];
 
         XCTAssertNil(result);
@@ -1618,9 +1619,9 @@
     KIOQuery *query = [[KIOQuery alloc] initWithQuery:@"count" andPropertiesDictionary:@{@"event_collection": @"event_collection"}];
 
     [mock runQuery:query completionHandler:^(NSData *queryResponseData, NSURLResponse *response, NSError *error) {
-        KCLog(@"error: %@", error);
-        KCLog(@"response: %@", response);
-
+        KCLogInfo(@"error: %@", error);
+        KCLogInfo(@"response: %@", response);
+        
         XCTAssertNil(error);
 
         NSHTTPURLResponse *httpResponse = (NSHTTPURLResponse*) response;
@@ -1630,9 +1631,9 @@
                                             JSONObjectWithData:queryResponseData
                                             options:kNilOptions
                                             error:&error];
-
-        KCLog(@"response: %@", responseDictionary);
-
+        
+        KCLogInfo(@"response: %@", responseDictionary);
+        
         NSNumber *result = [responseDictionary objectForKey:@"result"];
 
         XCTAssertEqual(result, [NSNumber numberWithInt:10]);
@@ -1646,9 +1647,9 @@
                                                                                          @"group_by": @"key"}];
 
     [mock runQuery:query completionHandler:^(NSData *queryResponseData, NSURLResponse *response, NSError *error) {
-        KCLog(@"error: %@", error);
-        KCLog(@"response: %@", response);
-
+        KCLogInfo(@"error: %@", error);
+        KCLogInfo(@"response: %@", response);
+        
         XCTAssertNil(error);
 
         NSHTTPURLResponse *httpResponse = (NSHTTPURLResponse*) response;
@@ -1658,9 +1659,9 @@
                                             JSONObjectWithData:queryResponseData
                                             options:kNilOptions
                                             error:&error];
-
-        KCLog(@"response: %@", responseDictionary);
-
+        
+        KCLogInfo(@"response: %@", responseDictionary);
+        
         NSNumber *result = [[responseDictionary objectForKey:@"result"][0] objectForKey:@"result"];
 
         XCTAssertEqual(result, [NSNumber numberWithInt:10]);
@@ -1677,9 +1678,9 @@
                                                        @"timeframe": @"last_1_days"}];
 
     [mock runQuery:query completionHandler:^(NSData *queryResponseData, NSURLResponse *response, NSError *error) {
-        KCLog(@"error: %@", error);
-        KCLog(@"response: %@", response);
-
+        KCLogInfo(@"error: %@", error);
+        KCLogInfo(@"response: %@", response);
+        
         XCTAssertNil(error);
 
         NSHTTPURLResponse *httpResponse = (NSHTTPURLResponse*) response;
@@ -1689,9 +1690,9 @@
                                             JSONObjectWithData:queryResponseData
                                             options:kNilOptions
                                             error:&error];
-
-        KCLog(@"response: %@", responseDictionary);
-
+        
+        KCLogInfo(@"response: %@", responseDictionary);
+        
         NSNumber *result = [[responseDictionary objectForKey:@"result"][0] objectForKey:@"value"];
 
         XCTAssertEqual(result, [NSNumber numberWithInt:10]);
@@ -1704,9 +1705,9 @@
     KIOQuery *query = [[KIOQuery alloc] initWithQuery:@"count" andPropertiesDictionary:@{@"event_collection": @"event_collection"}];
 
     [mock runQuery:query completionHandler:^(NSData *queryResponseData, NSURLResponse *response, NSError *error) {
-        KCLog(@"error: %@", error);
-        KCLog(@"response: %@", response);
-
+        KCLogInfo(@"error: %@", error);
+        KCLogInfo(@"response: %@", response);
+        
         XCTAssertNil(error);
 
         NSHTTPURLResponse *httpResponse = (NSHTTPURLResponse*) response;
@@ -1716,9 +1717,9 @@
                                             JSONObjectWithData:queryResponseData
                                             options:kNilOptions
                                             error:&error];
-
-        KCLog(@"response: %@", responseDictionary);
-
+        
+        KCLogInfo(@"response: %@", responseDictionary);
+        
         NSNumber *result = [responseDictionary objectForKey:@"result"];
 
         XCTAssertNil(result);
@@ -1731,9 +1732,9 @@
     KIOQuery *query = [[KIOQuery alloc] initWithQuery:@"count" andPropertiesDictionary:@{@"event_collection": @"event_collection", @"target_property": @"something"}];
 
     [mock runQuery:query completionHandler:^(NSData *queryResponseData, NSURLResponse *response, NSError *error) {
-        KCLog(@"error: %@", error);
-        KCLog(@"response: %@", response);
-
+        KCLogInfo(@"error: %@", error);
+        KCLogInfo(@"response: %@", response);
+        
         XCTAssertNil(error);
 
         NSHTTPURLResponse *httpResponse = (NSHTTPURLResponse*) response;
@@ -1743,9 +1744,9 @@
                                             JSONObjectWithData:queryResponseData
                                             options:kNilOptions
                                             error:&error];
-
-        KCLog(@"response: %@", responseDictionary);
-
+        
+        KCLogInfo(@"response: %@", responseDictionary);
+        
         NSNumber *result = [responseDictionary objectForKey:@"result"];
 
         XCTAssertEqual(result, [NSNumber numberWithInt:10]);
@@ -1760,9 +1761,9 @@
     KIOQuery *averageQuery = [[KIOQuery alloc] initWithQuery:@"count_unique" andPropertiesDictionary:@{@"event_collection": @"event_collection", @"target_property": @"something"}];
 
     [mock runMultiAnalysisWithQueries:@[countQuery, averageQuery] completionHandler:^(NSData *queryResponseData, NSURLResponse *response, NSError *error) {
-        KCLog(@"error: %@", error);
-        KCLog(@"response: %@", response);
-
+        KCLogInfo(@"error: %@", error);
+        KCLogInfo(@"response: %@", response);
+        
         XCTAssertNil(error);
 
         NSHTTPURLResponse *httpResponse = (NSHTTPURLResponse*) response;
@@ -1772,9 +1773,9 @@
                                             JSONObjectWithData:queryResponseData
                                             options:kNilOptions
                                             error:&error];
-
-        KCLog(@"response: %@", responseDictionary);
-
+        
+        KCLogInfo(@"response: %@", responseDictionary);
+        
         NSNumber *result = [[responseDictionary objectForKey:@"result"] objectForKey:@"query1"];
 
         XCTAssertEqual(result, [NSNumber numberWithInt:10]);
@@ -1792,9 +1793,9 @@
                                                                                                       @{@"event_collection": @"user_completed_profile", @"actor_property": @"user.id"}]}];
 
     [mock runQuery:query completionHandler:^(NSData *queryResponseData, NSURLResponse *response, NSError *error) {
-        KCLog(@"error: %@", error);
-        KCLog(@"response: %@", response);
-
+        KCLogInfo(@"error: %@", error);
+        KCLogInfo(@"response: %@", response);
+        
         XCTAssertNil(error);
 
         NSHTTPURLResponse *httpResponse = (NSHTTPURLResponse*) response;
@@ -1804,15 +1805,15 @@
                                             JSONObjectWithData:queryResponseData
                                             options:kNilOptions
                                             error:&error];
-
-        KCLog(@"response: %@", responseDictionary);
-
+        
+        KCLogInfo(@"response: %@", responseDictionary);
+        
         NSArray *result = [responseDictionary objectForKey:@"result"];
         NSArray *resultArray = @[@10, @5];
-
-        KCLog(@"result: %@", [result class]);
-        KCLog(@"resultArray: %@", [resultArray class]);
-
+        
+        KCLogInfo(@"result: %@", [result class]);
+        KCLogInfo(@"resultArray: %@", [resultArray class]);
+        
         XCTAssertEqual([result count], (NSUInteger)2);
         XCTAssertEqualObjects(result, resultArray);
     }];
@@ -2014,10 +2015,10 @@
     // write file atomically so we don't ever have a partial event to worry about.
     BOOL success = [data writeToFile:file atomically:YES];
     if (!success) {
-        KCLog(@"Error when writing event to file: %@", file);
+        KCLogError(@"Error when writing event to file: %@", file);
         return NO;
     } else {
-        KCLog(@"Successfully wrote event to file: %@", file);
+        KCLogInfo(@"Successfully wrote event to file: %@", file);
     }
     return YES;
 }

--- a/KeenClientTests/KeenClientTests.m
+++ b/KeenClientTests/KeenClientTests.m
@@ -471,7 +471,7 @@
                  andRequestValidator:(BOOL (^)(id requestObject))requestValidator {
     // Mock the NSURLSession to be used for the request
     id urlSessionMock = [OCMockObject partialMockForObject:[NSURLSession sharedSession]];
-    
+
     // Set up fake response data and request validation
     if (nil != requestValidator) {
         // Set up validation of the request
@@ -481,9 +481,9 @@
         // We won't check that the request contained anything specific
         [[urlSessionMock stub] dataTaskWithRequest:[OCMArg any]
                                  completionHandler:[OCMArg invokeBlockWithArgs:responseData, response, [NSNull null], nil]];
-        
+
     }
-    
+
     // Inject the mock NSURLSession
     [[[mockClient stub] andReturn:urlSessionMock] sharedUrlSession];
 }
@@ -506,7 +506,7 @@
                                                                error:nil];
 
     NSHTTPURLResponse *response = [[NSHTTPURLResponse alloc] initWithURL:[NSURL URLWithString:@""] statusCode:code HTTPVersion:nil headerFields:nil];
-    
+
     // Set up the NSURLSession mock
     [self mockUrlSessionWithMockClient:mock
                           withResponse:response
@@ -539,13 +539,13 @@
     NSData *serializedData = [NSJSONSerialization dataWithJSONObject:responseData
                                                              options:0
                                                                error:nil];
-    
+
     // Set up the NSURLSession mock
     [self mockUrlSessionWithMockClient:mock
                           withResponse:response
                        andResponseData:serializedData
                    andRequestValidator:requestValidator];
-    
+
     return mock;
 }
 
@@ -569,13 +569,13 @@
     NSData *serializedData = [NSJSONSerialization dataWithJSONObject:responseData
                                                              options:0
                                                                error:nil];
-    
+
     // Set up the NSURLSession mock
     [self mockUrlSessionWithMockClient:mock
                           withResponse:response
                        andResponseData:serializedData
                    andRequestValidator:requestValidator];
-    
+
     return mock;
 }
 
@@ -1594,7 +1594,7 @@
     [mock runQuery:query completionHandler:^(NSData *queryResponseData, NSURLResponse *response, NSError *error) {
         KCLogInfo(@"error: %@", error);
         KCLogInfo(@"response: %@", response);
-        
+
         XCTAssertNil(error);
 
         NSHTTPURLResponse *httpResponse = (NSHTTPURLResponse*) response;
@@ -1604,9 +1604,9 @@
                                             JSONObjectWithData:queryResponseData
                                             options:kNilOptions
                                             error:&error];
-        
+
         KCLogInfo(@"response: %@", responseDictionary);
-        
+
         NSNumber *result = [responseDictionary objectForKey:@"result"];
 
         XCTAssertNil(result);
@@ -1621,7 +1621,7 @@
     [mock runQuery:query completionHandler:^(NSData *queryResponseData, NSURLResponse *response, NSError *error) {
         KCLogInfo(@"error: %@", error);
         KCLogInfo(@"response: %@", response);
-        
+
         XCTAssertNil(error);
 
         NSHTTPURLResponse *httpResponse = (NSHTTPURLResponse*) response;
@@ -1631,9 +1631,9 @@
                                             JSONObjectWithData:queryResponseData
                                             options:kNilOptions
                                             error:&error];
-        
+
         KCLogInfo(@"response: %@", responseDictionary);
-        
+
         NSNumber *result = [responseDictionary objectForKey:@"result"];
 
         XCTAssertEqual(result, [NSNumber numberWithInt:10]);
@@ -1649,7 +1649,7 @@
     [mock runQuery:query completionHandler:^(NSData *queryResponseData, NSURLResponse *response, NSError *error) {
         KCLogInfo(@"error: %@", error);
         KCLogInfo(@"response: %@", response);
-        
+
         XCTAssertNil(error);
 
         NSHTTPURLResponse *httpResponse = (NSHTTPURLResponse*) response;
@@ -1659,9 +1659,9 @@
                                             JSONObjectWithData:queryResponseData
                                             options:kNilOptions
                                             error:&error];
-        
+
         KCLogInfo(@"response: %@", responseDictionary);
-        
+
         NSNumber *result = [[responseDictionary objectForKey:@"result"][0] objectForKey:@"result"];
 
         XCTAssertEqual(result, [NSNumber numberWithInt:10]);
@@ -1680,7 +1680,7 @@
     [mock runQuery:query completionHandler:^(NSData *queryResponseData, NSURLResponse *response, NSError *error) {
         KCLogInfo(@"error: %@", error);
         KCLogInfo(@"response: %@", response);
-        
+
         XCTAssertNil(error);
 
         NSHTTPURLResponse *httpResponse = (NSHTTPURLResponse*) response;
@@ -1690,9 +1690,9 @@
                                             JSONObjectWithData:queryResponseData
                                             options:kNilOptions
                                             error:&error];
-        
+
         KCLogInfo(@"response: %@", responseDictionary);
-        
+
         NSNumber *result = [[responseDictionary objectForKey:@"result"][0] objectForKey:@"value"];
 
         XCTAssertEqual(result, [NSNumber numberWithInt:10]);
@@ -1707,7 +1707,7 @@
     [mock runQuery:query completionHandler:^(NSData *queryResponseData, NSURLResponse *response, NSError *error) {
         KCLogInfo(@"error: %@", error);
         KCLogInfo(@"response: %@", response);
-        
+
         XCTAssertNil(error);
 
         NSHTTPURLResponse *httpResponse = (NSHTTPURLResponse*) response;
@@ -1717,9 +1717,9 @@
                                             JSONObjectWithData:queryResponseData
                                             options:kNilOptions
                                             error:&error];
-        
+
         KCLogInfo(@"response: %@", responseDictionary);
-        
+
         NSNumber *result = [responseDictionary objectForKey:@"result"];
 
         XCTAssertNil(result);
@@ -1734,7 +1734,7 @@
     [mock runQuery:query completionHandler:^(NSData *queryResponseData, NSURLResponse *response, NSError *error) {
         KCLogInfo(@"error: %@", error);
         KCLogInfo(@"response: %@", response);
-        
+
         XCTAssertNil(error);
 
         NSHTTPURLResponse *httpResponse = (NSHTTPURLResponse*) response;
@@ -1744,9 +1744,9 @@
                                             JSONObjectWithData:queryResponseData
                                             options:kNilOptions
                                             error:&error];
-        
+
         KCLogInfo(@"response: %@", responseDictionary);
-        
+
         NSNumber *result = [responseDictionary objectForKey:@"result"];
 
         XCTAssertEqual(result, [NSNumber numberWithInt:10]);
@@ -1763,7 +1763,7 @@
     [mock runMultiAnalysisWithQueries:@[countQuery, averageQuery] completionHandler:^(NSData *queryResponseData, NSURLResponse *response, NSError *error) {
         KCLogInfo(@"error: %@", error);
         KCLogInfo(@"response: %@", response);
-        
+
         XCTAssertNil(error);
 
         NSHTTPURLResponse *httpResponse = (NSHTTPURLResponse*) response;
@@ -1773,9 +1773,9 @@
                                             JSONObjectWithData:queryResponseData
                                             options:kNilOptions
                                             error:&error];
-        
+
         KCLogInfo(@"response: %@", responseDictionary);
-        
+
         NSNumber *result = [[responseDictionary objectForKey:@"result"] objectForKey:@"query1"];
 
         XCTAssertEqual(result, [NSNumber numberWithInt:10]);
@@ -1795,7 +1795,7 @@
     [mock runQuery:query completionHandler:^(NSData *queryResponseData, NSURLResponse *response, NSError *error) {
         KCLogInfo(@"error: %@", error);
         KCLogInfo(@"response: %@", response);
-        
+
         XCTAssertNil(error);
 
         NSHTTPURLResponse *httpResponse = (NSHTTPURLResponse*) response;
@@ -1805,15 +1805,15 @@
                                             JSONObjectWithData:queryResponseData
                                             options:kNilOptions
                                             error:&error];
-        
+
         KCLogInfo(@"response: %@", responseDictionary);
-        
+
         NSArray *result = [responseDictionary objectForKey:@"result"];
         NSArray *resultArray = @[@10, @5];
-        
+
         KCLogInfo(@"result: %@", [result class]);
         KCLogInfo(@"resultArray: %@", [resultArray class]);
-        
+
         XCTAssertEqual([result count], (NSUInteger)2);
         XCTAssertEqualObjects(result, resultArray);
     }];
@@ -1877,28 +1877,28 @@
 
 - (void)testSdkTrackingHeadersOnUpload {
     // mock an empty response from the server
-    
+
     id mock = [self uploadTestHelperWithRequestValidator:^BOOL(id obj) {
         [self validateSdkVersionHeaderFieldForRequest:obj];
         return @YES;
     }];
-    
+
     // Get the mock url session. We'll check the request it gets passed by sendEvents for the version header
     id urlSessionMock = [mock sharedUrlSession];
-    
+
     // add an event
     [mock addEvent:[NSDictionary dictionaryWithObject:@"apple" forKey:@"a"] toEventCollection:@"foo" error:nil];
-    
+
     XCTestExpectation* responseArrived = [self expectationWithDescription:@"response of async request has arrived"];
     // and "upload" it
     [mock uploadWithFinishedBlock:^{
-        
+
         // Check for the sdk version header
         [urlSessionMock verify];
-        
+
         [responseArrived fulfill];
     }];
-    
+
     [self waitForExpectationsWithTimeout:_asyncTimeInterval handler:^(NSError * _Nullable error) {
         XCTAssertNil(error, @"Test should complete within expected interval.");
     }];
@@ -1909,20 +1909,20 @@
         [self validateSdkVersionHeaderFieldForRequest:obj];
         return @YES;
     }];
-    
+
     // Get the mock url session. We'll check the request it gets passed by sendEvents for the version header
     id urlSessionMock = [mock sharedUrlSession];
-    
+
     KIOQuery *query = [[KIOQuery alloc] initWithQuery:@"count" andPropertiesDictionary:@{@"event_collection": @"event_collection"}];
-    
+
     XCTestExpectation* responseArrived = [self expectationWithDescription:@"response of async request has arrived"];
     [mock runQuery:query completionHandler:^(NSData *queryResponseData, NSURLResponse *response, NSError *error) {
         // Check for the sdk version header
         [urlSessionMock verify];
-        
+
         [responseArrived fulfill];
     }];
-    
+
     [self waitForExpectationsWithTimeout:_asyncTimeInterval handler:^(NSError * _Nullable error) {
         XCTAssertNil(error, @"Test should complete within expected interval.");
     }];
@@ -1935,22 +1935,22 @@
         [self validateSdkVersionHeaderFieldForRequest:obj];
         return @YES;
     }];
-    
+
     // Get the mock url session. We'll check the request it gets passed by sendEvents for the version header
     id urlSessionMock = [mock sharedUrlSession];
-    
+
     KIOQuery *countQuery = [[KIOQuery alloc] initWithQuery:@"count" andPropertiesDictionary:@{@"event_collection": @"event_collection"}];
-    
+
     KIOQuery *averageQuery = [[KIOQuery alloc] initWithQuery:@"count_unique" andPropertiesDictionary:@{@"event_collection": @"event_collection", @"target_property": @"something"}];
-    
+
     XCTestExpectation* responseArrived = [self expectationWithDescription:@"response of async request has arrived"];
     [mock runMultiAnalysisWithQueries:@[countQuery, averageQuery] completionHandler:^(NSData *queryResponseData, NSURLResponse *response, NSError *error) {
         // Check for the sdk version header
         [urlSessionMock verify];
-        
+
         [responseArrived fulfill];
     }];
-    
+
     [self waitForExpectationsWithTimeout:_asyncTimeInterval handler:^(NSError * _Nullable error) {
         XCTAssertNil(error, @"Test should complete within expected interval.");
     }];

--- a/KeenClientTests/KeenLoggerTests.h
+++ b/KeenClientTests/KeenLoggerTests.h
@@ -1,0 +1,13 @@
+//
+//  KeenLoggerTests.h
+//  KeenClient
+//
+//  Created by Brian Baumhover on 2/18/17.
+//  Copyright © 2017 Keen Labs. All rights reserved.
+//
+
+#import <XCTest/XCTest.h>
+
+@interface KeenLoggerTests : XCTestCase
+
+@end

--- a/KeenClientTests/KeenLoggerTests.m
+++ b/KeenClientTests/KeenLoggerTests.m
@@ -121,7 +121,7 @@ BOOL removed;
 
 - (void)testSimpleLogging {
     NSArray* testMessages =
-        [[NSArray alloc] initWithObjects:[[Message alloc] initWithLogLevel:KLL_ERROR andText:@"error message"], nil];
+        [[NSArray alloc] initWithObjects:[[Message alloc] initWithLogLevel:KeenLogLevelError andText:@"error message"], nil];
     
     KeenLogger* testLogger = [[KeenLogger alloc] init];
     
@@ -143,7 +143,7 @@ BOOL removed;
 
 - (void)testEnableAndDisable {
     NSArray* testMessages =
-        [[NSArray alloc] initWithObjects:[[Message alloc] initWithLogLevel:KLL_ERROR andText:@"error message"], nil];
+        [[NSArray alloc] initWithObjects:[[Message alloc] initWithLogLevel:KeenLogLevelError andText:@"error message"], nil];
     
     KeenLogger* testLogger = [[KeenLogger alloc] init];
 
@@ -193,32 +193,32 @@ BOOL removed;
 - (void)testLogLevels {
     NSArray* testMessages =
         [[NSArray alloc] initWithObjects:
-            [[Message alloc] initWithLogLevel:KLL_ERROR andText:@"error message"],
-            [[Message alloc] initWithLogLevel:KLL_WARNING andText:@"warning message"],
-            [[Message alloc] initWithLogLevel:KLL_INFO andText:@"info message"],
-            [[Message alloc] initWithLogLevel:KLL_VERBOSE andText:@"verbose message"],
+            [[Message alloc] initWithLogLevel:KeenLogLevelError andText:@"error message"],
+            [[Message alloc] initWithLogLevel:KeenLogLevelWarning andText:@"warning message"],
+            [[Message alloc] initWithLogLevel:KeenLogLevelInfo andText:@"info message"],
+            [[Message alloc] initWithLogLevel:KeenLogLevelVerbose andText:@"verbose message"],
             nil];
     NSArray* errorLevelMessages =
         [[NSArray alloc] initWithObjects:
-            [[Message alloc] initWithLogLevel:KLL_ERROR andText:@"error message"],
+            [[Message alloc] initWithLogLevel:KeenLogLevelError andText:@"error message"],
             nil];
     NSArray* warningLevelMessages =
         [[NSArray alloc] initWithObjects:
-            [[Message alloc] initWithLogLevel:KLL_ERROR andText:@"error message"],
-            [[Message alloc] initWithLogLevel:KLL_WARNING andText:@"warning message"],
+            [[Message alloc] initWithLogLevel:KeenLogLevelError andText:@"error message"],
+            [[Message alloc] initWithLogLevel:KeenLogLevelWarning andText:@"warning message"],
             nil];
     NSArray* infoLevelMessages =
         [[NSArray alloc] initWithObjects:
-            [[Message alloc] initWithLogLevel:KLL_ERROR andText:@"error message"],
-            [[Message alloc] initWithLogLevel:KLL_WARNING andText:@"warning message"],
-            [[Message alloc] initWithLogLevel:KLL_INFO andText:@"info message"],
+            [[Message alloc] initWithLogLevel:KeenLogLevelError andText:@"error message"],
+            [[Message alloc] initWithLogLevel:KeenLogLevelWarning andText:@"warning message"],
+            [[Message alloc] initWithLogLevel:KeenLogLevelInfo andText:@"info message"],
             nil];
     NSArray* verboseLevelMessages =
         [[NSArray alloc] initWithObjects:
-            [[Message alloc] initWithLogLevel:KLL_ERROR andText:@"error message"],
-            [[Message alloc] initWithLogLevel:KLL_WARNING andText:@"warning message"],
-            [[Message alloc] initWithLogLevel:KLL_INFO andText:@"info message"],
-            [[Message alloc] initWithLogLevel:KLL_VERBOSE andText:@"verbose message"],
+            [[Message alloc] initWithLogLevel:KeenLogLevelError andText:@"error message"],
+            [[Message alloc] initWithLogLevel:KeenLogLevelWarning andText:@"warning message"],
+            [[Message alloc] initWithLogLevel:KeenLogLevelInfo andText:@"info message"],
+            [[Message alloc] initWithLogLevel:KeenLogLevelVerbose andText:@"verbose message"],
             nil];
     
     KeenLogger* testLogger = [[KeenLogger alloc] init];
@@ -230,7 +230,7 @@ BOOL removed;
     // Enable logging
     [testLogger enableLogging];
     
-    // Default log level is KLL_ERROR, test that log level
+    // Default log level is KeenLogLevelError, test that log level
     [self logMessages:testMessages usingLogger:testLogger];
     
     // Verify messages received
@@ -243,7 +243,7 @@ BOOL removed;
     [testLogger addLogSink:testSink];
     
     // Log messages
-    [testLogger setLogLevel:KLL_WARNING];
+    [testLogger setLogLevel:KeenLogLevelWarning];
     [self logMessages:testMessages usingLogger:testLogger];
     
     // Verify messages received
@@ -256,7 +256,7 @@ BOOL removed;
     [testLogger addLogSink:testSink];
     
     // Log messages
-    [testLogger setLogLevel:KLL_INFO];
+    [testLogger setLogLevel:KeenLogLevelInfo];
     [self logMessages:testMessages usingLogger:testLogger];
     
     // Verify messages received
@@ -269,7 +269,7 @@ BOOL removed;
     [testLogger addLogSink:testSink];
     
     // Log messages
-    [testLogger setLogLevel:KLL_VERBOSE];
+    [testLogger setLogLevel:KeenLogLevelVerbose];
     [self logMessages:testMessages usingLogger:testLogger];
     
     // Verify messages received

--- a/KeenClientTests/KeenLoggerTests.m
+++ b/KeenClientTests/KeenLoggerTests.m
@@ -42,44 +42,54 @@
 
 @implementation TestLogSink
 
-NSMutableArray* loggedMessages;
-NSCondition* removalCondition;
-BOOL removed;
+NSMutableArray* _loggedMessages;
+NSCondition* _removalCondition;
+BOOL _removed;
+BOOL _logToNSLog;
 
-- (TestLogSink*)init {
+
+- (instancetype)init {
+    return [self initWithLogToNSLog:YES];
+}
+
+
+- (instancetype)initWithLogToNSLog:(BOOL)logToNSLog {
     self = [super init];
     if (nil != self) {
-        loggedMessages = [[NSMutableArray alloc] init];
-        removalCondition = [[NSCondition alloc] init];
-        removed = NO;
+        _loggedMessages = [[NSMutableArray alloc] init];
+        _removalCondition = [[NSCondition alloc] init];
+        _removed = NO;
+        _logToNSLog = logToNSLog;
     }
     return self;
 }
 
 - (void)logMessageWithLevel:(KeenLogLevel)msgLevel andMessage:(NSString *)message {
-    NSLog(@"LogSink: %@", message);
-    [loggedMessages addObject:[[Message alloc] initWithLogLevel:msgLevel andText:message]];
+    if (_logToNSLog) {
+        NSLog(@"LogSink: %@", message);
+    }
+    [_loggedMessages addObject:[[Message alloc] initWithLogLevel:msgLevel andText:message]];
 }
 
 - (void)onRemoved {
-    [removalCondition lock];
-    removed = YES;
-    [removalCondition signal];
-    [removalCondition unlock];
+    [_removalCondition lock];
+    _removed = YES;
+    [_removalCondition signal];
+    [_removalCondition unlock];
 }
 
 // Wait for a signal that's triggered when the logger is removed.
 // We'll use this as a way to see if all messages have been drained and recorded.
 - (BOOL)waitForRemoval {
     BOOL wasRemoved = NO;
-    [removalCondition lock];
-    if (removed) {
+    [_removalCondition lock];
+    if (_removed) {
         wasRemoved = YES;
-        [removalCondition unlock];
+        [_removalCondition unlock];
     } else {
-        if ([removalCondition waitUntilDate:[NSDate dateWithTimeIntervalSinceNow:5]]) {
-            wasRemoved = removed;
-            [removalCondition unlock];
+        if ([_removalCondition waitUntilDate:[NSDate dateWithTimeIntervalSinceNow:5]]) {
+            wasRemoved = _removed;
+            [_removalCondition unlock];
         } else {
             wasRemoved = NO;
         }
@@ -88,7 +98,7 @@ BOOL removed;
 }
 
 - (NSArray*)getLoggedMessages {
-    return loggedMessages;
+    return _loggedMessages;
 }
 
 @end
@@ -101,6 +111,7 @@ BOOL removed;
 // when the logger is removed, then do validation of the received messages to expected
 // messages.
 
+
 // Helper method for logging messages
 - (void)logMessages:(NSArray*)messages usingLogger:(KeenLogger*)logger {
     for (Message* message in messages) {
@@ -108,16 +119,20 @@ BOOL removed;
     }
 }
 
+
 // Helper method for checking for correctly logged messages
 - (void)verifyLoggedMessages:(NSArray*)actual withExpectedMessages:(NSArray*)expected {
     XCTAssertEqual(actual.count, expected.count, @"Message count wasn't expected number.");
-    for (NSUInteger i = 0; i < expected.count; ++i) {
-        Message* expectedMsg = [expected objectAtIndex:i];
-        Message* actualMsg = [actual objectAtIndex:i];
-        XCTAssertEqual(expectedMsg.logLevel, actualMsg.logLevel, @"Log level of message was incorrect.");
-        XCTAssertEqualObjects(expectedMsg.text, actualMsg.text, @"Log text of message was incorrect.");
+    if (actual.count == expected.count) {
+        for (NSUInteger i = 0; i < expected.count; ++i) {
+            Message* expectedMsg = [expected objectAtIndex:i];
+            Message* actualMsg = [actual objectAtIndex:i];
+            XCTAssertEqual(expectedMsg.logLevel, actualMsg.logLevel, @"Log level of message was incorrect.");
+            XCTAssertEqualObjects(expectedMsg.text, actualMsg.text, @"Log text of message was incorrect.");
+        }
     }
 }
+
 
 - (void)testSimpleLogging {
     NSArray* testMessages =
@@ -140,6 +155,83 @@ BOOL removed;
     [testSink waitForRemoval];
     [self verifyLoggedMessages:[testSink getLoggedMessages] withExpectedMessages:testMessages];
 }
+
+
+- (void)testEnableNSLogLogging {
+    [self runNSLogTest:YES];
+}
+
+
+- (void)testDisableNSLogLogging {
+    [self runNSLogTest:NO];
+}
+
+
+- (void)runNSLogTest:(BOOL)enableNSLog {
+    NSArray* testMessages =
+    [[NSArray alloc] initWithObjects:[[Message alloc] initWithLogLevel:KeenLogLevelError andText:@"error message"], nil];
+    NSString* expectedMessage = @"E:error message";
+
+    KeenLogger* testLogger = [[KeenLogger alloc] init];
+
+    // 1. Add a LogSink
+    TestLogSink* testSink = [[TestLogSink alloc] initWithLogToNSLog:NO];
+    [testLogger addLogSink:testSink];
+
+    // 2. Enable logging
+    [testLogger enableLogging];
+
+    // 3. Disable or enable NSLog logging
+    [testLogger setIsNSLogEnabled:enableNSLog];
+
+    // Create a duplicate of the current stderr file descriptor
+    int savedStdErr = dup(STDERR_FILENO);
+
+    // Reopen stderr and point it to a writable temporary file
+    FILE* newStderr = freopen("test.log", "w", stderr);
+    XCTAssertTrue(newStderr != NULL, @"Failed to open log file for output");
+    
+    // 4. log messages
+    [self logMessages:testMessages usingLogger:testLogger];
+
+    // Ensure all messages were handled before continuing
+    [testLogger removeLogSink:testSink];
+    [testSink waitForRemoval];
+
+    // Flush stderr to make sure all messages are written
+    fflush(stderr);
+
+    // Reset stderr by duplicating the saved file descriptor to the stderr file descriptor
+    dup2(savedStdErr, STDERR_FILENO);
+    // Close the saved file descriptor as we're done with it
+    close(savedStdErr);
+    close(newStderr);
+
+    // 5. verify message was/wasn't logged to NSLog
+    const size_t cchMaxStringLength = 256;
+    char* pchString = malloc(cchMaxStringLength);
+    // Open the file stderr wrote to
+    FILE* logOutputFile = fopen("test.log", "r");
+    XCTAssertTrue(NULL != logOutputFile, @"Failed to open log output file. error: %d", errno);
+    // Read the file contents
+    fread(pchString, sizeof(char), cchMaxStringLength - 1, logOutputFile);
+    fclose(logOutputFile);
+    // Ensure the string is null terminated
+    pchString[cchMaxStringLength - 1] = '\0';
+    // Create an NSString from the c string
+    NSString* loggedString = [NSString stringWithCString:pchString encoding:NSASCIIStringEncoding];
+    // Find the expected message in the output
+    NSRange expectedMessageRange = [loggedString rangeOfString:expectedMessage];
+
+    if (enableNSLog) {
+        XCTAssertTrue(expectedMessageRange.location != NSNotFound, @"Logged message wasn't contained in output.");
+    } else {
+        XCTAssertTrue(expectedMessageRange.location == NSNotFound, @"Logged message was contained in output.");
+    }
+
+    [self verifyLoggedMessages:[testSink getLoggedMessages] withExpectedMessages:testMessages];
+}
+
 
 - (void)testEnableAndDisable {
     NSArray* testMessages =
@@ -189,6 +281,7 @@ BOOL removed;
     [testSink waitForRemoval];
     XCTAssertEqual(0, [testSink getLoggedMessages].count, @"Logging was disabled, so no messages should have been recorded.");
 }
+
 
 - (void)testLogLevels {
     NSArray* testMessages =
@@ -277,5 +370,6 @@ BOOL removed;
     [testSink waitForRemoval];
     [self verifyLoggedMessages:[testSink getLoggedMessages] withExpectedMessages:verboseLevelMessages];
 }
+
 
 @end

--- a/KeenClientTests/KeenLoggerTests.m
+++ b/KeenClientTests/KeenLoggerTests.m
@@ -122,19 +122,19 @@ BOOL removed;
 - (void)testSimpleLogging {
     NSArray* testMessages =
         [[NSArray alloc] initWithObjects:[[Message alloc] initWithLogLevel:KeenLogLevelError andText:@"error message"], nil];
-    
+
     KeenLogger* testLogger = [[KeenLogger alloc] init];
-    
+
     // 1. Add a LogSink
     TestLogSink* testSink = [[TestLogSink alloc] init];
     [testLogger addLogSink:testSink];
-    
+
     // 2. Enable logging
     [testLogger enableLogging];
-    
+
     // 3. log messages
     [self logMessages:testMessages usingLogger:testLogger];
-    
+
     // 4. verify message was logged
     [testLogger removeLogSink:testSink];
     [testSink waitForRemoval];
@@ -144,7 +144,7 @@ BOOL removed;
 - (void)testEnableAndDisable {
     NSArray* testMessages =
         [[NSArray alloc] initWithObjects:[[Message alloc] initWithLogLevel:KeenLogLevelError andText:@"error message"], nil];
-    
+
     KeenLogger* testLogger = [[KeenLogger alloc] init];
 
     // Add a log sink
@@ -162,13 +162,13 @@ BOOL removed;
     // Add a new log sink
     testSink = [[TestLogSink alloc] init];
     [testLogger addLogSink:testSink];
-    
+
     // Enable logging
     [testLogger enableLogging];
-    
+
     // Log more messages
     [self logMessages:testMessages usingLogger:testLogger];
-    
+
     // Verify messages received
     [testLogger removeLogSink:testSink];
     [testSink waitForRemoval];
@@ -176,14 +176,14 @@ BOOL removed;
 
     // Disable logging
     [testLogger disableLogging];
-    
+
     // Add a new log sink
     testSink = [[TestLogSink alloc] init];
     [testLogger addLogSink:testSink];
-    
+
     // log more messages
     [self logMessages:testMessages usingLogger:testLogger];
-    
+
     // Verfy no messages received.
     [testLogger removeLogSink:testSink];
     [testSink waitForRemoval];
@@ -220,19 +220,19 @@ BOOL removed;
             [[Message alloc] initWithLogLevel:KeenLogLevelInfo andText:@"info message"],
             [[Message alloc] initWithLogLevel:KeenLogLevelVerbose andText:@"verbose message"],
             nil];
-    
+
     KeenLogger* testLogger = [[KeenLogger alloc] init];
-    
+
     // Add a log sink
     TestLogSink* testSink = [[TestLogSink alloc] init];
     [testLogger addLogSink:testSink];
 
     // Enable logging
     [testLogger enableLogging];
-    
+
     // Default log level is KeenLogLevelError, test that log level
     [self logMessages:testMessages usingLogger:testLogger];
-    
+
     // Verify messages received
     [testLogger removeLogSink:testSink];
     [testSink waitForRemoval];
@@ -241,37 +241,37 @@ BOOL removed;
     // Add a new log sink
     testSink = [[TestLogSink alloc] init];
     [testLogger addLogSink:testSink];
-    
+
     // Log messages
     [testLogger setLogLevel:KeenLogLevelWarning];
     [self logMessages:testMessages usingLogger:testLogger];
-    
+
     // Verify messages received
     [testLogger removeLogSink:testSink];
     [testSink waitForRemoval];
     [self verifyLoggedMessages:[testSink getLoggedMessages] withExpectedMessages:warningLevelMessages];
-    
+
     // Add a new log sink
     testSink = [[TestLogSink alloc] init];
     [testLogger addLogSink:testSink];
-    
+
     // Log messages
     [testLogger setLogLevel:KeenLogLevelInfo];
     [self logMessages:testMessages usingLogger:testLogger];
-    
+
     // Verify messages received
     [testLogger removeLogSink:testSink];
     [testSink waitForRemoval];
     [self verifyLoggedMessages:[testSink getLoggedMessages] withExpectedMessages:infoLevelMessages];
-    
+
     // Add a new log sink
     testSink = [[TestLogSink alloc] init];
     [testLogger addLogSink:testSink];
-    
+
     // Log messages
     [testLogger setLogLevel:KeenLogLevelVerbose];
     [self logMessages:testMessages usingLogger:testLogger];
-    
+
     // Verify messages received
     [testLogger removeLogSink:testSink];
     [testSink waitForRemoval];

--- a/KeenClientTests/KeenLoggerTests.m
+++ b/KeenClientTests/KeenLoggerTests.m
@@ -1,0 +1,281 @@
+//
+//  KeenLoggerTests.m
+//  KeenClient
+//
+//  Created by Brian Baumhover on 2/18/17.
+//  Copyright © 2017 Keen Labs. All rights reserved.
+//
+
+#import "KeenLoggerTests.h"
+#import "KeenLogger.h"
+
+//
+// Class to store messages we'll log or have logged.
+//
+@interface Message : NSObject
+- (Message*)initWithLogLevel:(KeenLogLevel)level andText:(NSString*)newText;
+@property KeenLogLevel logLevel;
+@property NSString* text;
+@end
+
+@implementation Message
+
+- (Message*)initWithLogLevel:(KeenLogLevel)level andText:(NSString*)newText {
+    self = [super init];
+    if (nil != self) {
+        logLevel = level;
+        text = newText;
+    }
+    return self;
+}
+
+@synthesize logLevel;
+@synthesize text;
+
+@end
+
+//
+// A log sink implementation for testing
+//
+@interface TestLogSink : NSObject<KeenLogSink>
+@end
+
+@implementation TestLogSink
+
+NSMutableArray* loggedMessages;
+NSCondition* removalCondition;
+BOOL removed;
+
+- (TestLogSink*)init {
+    self = [super init];
+    if (nil != self) {
+        loggedMessages = [[NSMutableArray alloc] init];
+        removalCondition = [[NSCondition alloc] init];
+        removed = NO;
+    }
+    return self;
+}
+
+- (void)logMessageWithLevel:(KeenLogLevel)msgLevel andMessage:(NSString *)message {
+    NSLog(@"LogSink: %@", message);
+    [loggedMessages addObject:[[Message alloc] initWithLogLevel:msgLevel andText:message]];
+}
+
+- (void)onRemoved {
+    [removalCondition lock];
+    removed = YES;
+    [removalCondition signal];
+    [removalCondition unlock];
+}
+
+// Wait for a signal that's triggered when the logger is removed.
+// We'll use this as a way to see if all messages have been drained and recorded.
+- (BOOL)waitForRemoval {
+    BOOL wasRemoved = NO;
+    [removalCondition lock];
+    if (removed) {
+        wasRemoved = YES;
+        [removalCondition unlock];
+    } else {
+        if ([removalCondition waitUntilDate:[NSDate dateWithTimeIntervalSinceNow:5]]) {
+            wasRemoved = removed;
+            [removalCondition unlock];
+        } else {
+            wasRemoved = NO;
+        }
+    }
+    return wasRemoved;
+}
+
+- (NSArray*)getLoggedMessages {
+    return loggedMessages;
+}
+
+@end
+
+
+@implementation KeenLoggerTests
+
+// For testing, can create a LogSink that is created with the expected messages
+// Then, do logging, and remove the logger. Create a signal that will be signaled
+// when the logger is removed, then do validation of the received messages to expected
+// messages.
+
+// Helper method for logging messages
+- (void)logMessages:(NSArray*)messages usingLogger:(KeenLogger*)logger {
+    for (Message* message in messages) {
+        [logger logMessageWithLevel:message.logLevel andMessage:message.text];
+    }
+}
+
+// Helper method for checking for correctly logged messages
+- (void)verifyLoggedMessages:(NSArray*)actual withExpectedMessages:(NSArray*)expected {
+    XCTAssertEqual(actual.count, expected.count, @"Message count wasn't expected number.");
+    for (NSUInteger i = 0; i < expected.count; ++i) {
+        Message* expectedMsg = [expected objectAtIndex:i];
+        Message* actualMsg = [actual objectAtIndex:i];
+        XCTAssertEqual(expectedMsg.logLevel, actualMsg.logLevel, @"Log level of message was incorrect.");
+        XCTAssertEqualObjects(expectedMsg.text, actualMsg.text, @"Log text of message was incorrect.");
+    }
+}
+
+- (void)testSimpleLogging {
+    NSArray* testMessages =
+        [[NSArray alloc] initWithObjects:[[Message alloc] initWithLogLevel:KLL_ERROR andText:@"error message"], nil];
+    
+    KeenLogger* testLogger = [[KeenLogger alloc] init];
+    
+    // 1. Add a LogSink
+    TestLogSink* testSink = [[TestLogSink alloc] init];
+    [testLogger addLogSink:testSink];
+    
+    // 2. Enable logging
+    [testLogger enableLogging];
+    
+    // 3. log messages
+    [self logMessages:testMessages usingLogger:testLogger];
+    
+    // 4. verify message was logged
+    [testLogger removeLogSink:testSink];
+    [testSink waitForRemoval];
+    [self verifyLoggedMessages:[testSink getLoggedMessages] withExpectedMessages:testMessages];
+}
+
+- (void)testEnableAndDisable {
+    NSArray* testMessages =
+        [[NSArray alloc] initWithObjects:[[Message alloc] initWithLogLevel:KLL_ERROR andText:@"error message"], nil];
+    
+    KeenLogger* testLogger = [[KeenLogger alloc] init];
+
+    // Add a log sink
+    TestLogSink* testSink = [[TestLogSink alloc] init];
+    [testLogger addLogSink:testSink];
+
+    // Try logging some messages
+    [self logMessages:testMessages usingLogger:testLogger];
+
+    // Verfy no messages received.
+    [testLogger removeLogSink:testSink];
+    [testSink waitForRemoval];
+    XCTAssertEqual(0, [testSink getLoggedMessages].count, @"Logging was disabled, so no messages should have been recorded.");
+
+    // Add a new log sink
+    testSink = [[TestLogSink alloc] init];
+    [testLogger addLogSink:testSink];
+    
+    // Enable logging
+    [testLogger enableLogging];
+    
+    // Log more messages
+    [self logMessages:testMessages usingLogger:testLogger];
+    
+    // Verify messages received
+    [testLogger removeLogSink:testSink];
+    [testSink waitForRemoval];
+    [self verifyLoggedMessages:[testSink getLoggedMessages] withExpectedMessages:testMessages];
+
+    // Disable logging
+    [testLogger disableLogging];
+    
+    // Add a new log sink
+    testSink = [[TestLogSink alloc] init];
+    [testLogger addLogSink:testSink];
+    
+    // log more messages
+    [self logMessages:testMessages usingLogger:testLogger];
+    
+    // Verfy no messages received.
+    [testLogger removeLogSink:testSink];
+    [testSink waitForRemoval];
+    XCTAssertEqual(0, [testSink getLoggedMessages].count, @"Logging was disabled, so no messages should have been recorded.");
+}
+
+- (void)testLogLevels {
+    NSArray* testMessages =
+        [[NSArray alloc] initWithObjects:
+            [[Message alloc] initWithLogLevel:KLL_ERROR andText:@"error message"],
+            [[Message alloc] initWithLogLevel:KLL_WARNING andText:@"warning message"],
+            [[Message alloc] initWithLogLevel:KLL_INFO andText:@"info message"],
+            [[Message alloc] initWithLogLevel:KLL_VERBOSE andText:@"verbose message"],
+            nil];
+    NSArray* errorLevelMessages =
+        [[NSArray alloc] initWithObjects:
+            [[Message alloc] initWithLogLevel:KLL_ERROR andText:@"error message"],
+            nil];
+    NSArray* warningLevelMessages =
+        [[NSArray alloc] initWithObjects:
+            [[Message alloc] initWithLogLevel:KLL_ERROR andText:@"error message"],
+            [[Message alloc] initWithLogLevel:KLL_WARNING andText:@"warning message"],
+            nil];
+    NSArray* infoLevelMessages =
+        [[NSArray alloc] initWithObjects:
+            [[Message alloc] initWithLogLevel:KLL_ERROR andText:@"error message"],
+            [[Message alloc] initWithLogLevel:KLL_WARNING andText:@"warning message"],
+            [[Message alloc] initWithLogLevel:KLL_INFO andText:@"info message"],
+            nil];
+    NSArray* verboseLevelMessages =
+        [[NSArray alloc] initWithObjects:
+            [[Message alloc] initWithLogLevel:KLL_ERROR andText:@"error message"],
+            [[Message alloc] initWithLogLevel:KLL_WARNING andText:@"warning message"],
+            [[Message alloc] initWithLogLevel:KLL_INFO andText:@"info message"],
+            [[Message alloc] initWithLogLevel:KLL_VERBOSE andText:@"verbose message"],
+            nil];
+    
+    KeenLogger* testLogger = [[KeenLogger alloc] init];
+    
+    // Add a log sink
+    TestLogSink* testSink = [[TestLogSink alloc] init];
+    [testLogger addLogSink:testSink];
+
+    // Enable logging
+    [testLogger enableLogging];
+    
+    // Default log level is KLL_ERROR, test that log level
+    [self logMessages:testMessages usingLogger:testLogger];
+    
+    // Verify messages received
+    [testLogger removeLogSink:testSink];
+    [testSink waitForRemoval];
+    [self verifyLoggedMessages:[testSink getLoggedMessages] withExpectedMessages:errorLevelMessages];
+
+    // Add a new log sink
+    testSink = [[TestLogSink alloc] init];
+    [testLogger addLogSink:testSink];
+    
+    // Log messages
+    [testLogger setLogLevel:KLL_WARNING];
+    [self logMessages:testMessages usingLogger:testLogger];
+    
+    // Verify messages received
+    [testLogger removeLogSink:testSink];
+    [testSink waitForRemoval];
+    [self verifyLoggedMessages:[testSink getLoggedMessages] withExpectedMessages:warningLevelMessages];
+    
+    // Add a new log sink
+    testSink = [[TestLogSink alloc] init];
+    [testLogger addLogSink:testSink];
+    
+    // Log messages
+    [testLogger setLogLevel:KLL_INFO];
+    [self logMessages:testMessages usingLogger:testLogger];
+    
+    // Verify messages received
+    [testLogger removeLogSink:testSink];
+    [testSink waitForRemoval];
+    [self verifyLoggedMessages:[testSink getLoggedMessages] withExpectedMessages:infoLevelMessages];
+    
+    // Add a new log sink
+    testSink = [[TestLogSink alloc] init];
+    [testLogger addLogSink:testSink];
+    
+    // Log messages
+    [testLogger setLogLevel:KLL_VERBOSE];
+    [self logMessages:testMessages usingLogger:testLogger];
+    
+    // Verify messages received
+    [testLogger removeLogSink:testSink];
+    [testSink waitForRemoval];
+    [self verifyLoggedMessages:[testSink getLoggedMessages] withExpectedMessages:verboseLevelMessages];
+}
+
+@end

--- a/KeenSwiftClientExample/KeenSwiftClientExample/AppDelegate.swift
+++ b/KeenSwiftClientExample/KeenSwiftClientExample/AppDelegate.swift
@@ -26,6 +26,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplicationLaunchOptionsKey: Any]?) -> Bool {
         // Override point for customization after application launch.
         KeenClient.addLogSink(ExampleLogger())
+        KeenClient.setIsNSLogEnabled(true);
         KeenClient.setLogLevel(.verbose)
         KeenClient.enableLogging()
         

--- a/KeenSwiftClientExample/KeenSwiftClientExample/AppDelegate.swift
+++ b/KeenSwiftClientExample/KeenSwiftClientExample/AppDelegate.swift
@@ -8,19 +8,30 @@
 
 import UIKit
 
+class ExampleLogger: KeenLogSink {
+    public func logMessage(with msgLevel: KeenLogLevel, andMessage message: String!) {
+        NSLog("%@", message)
+    }
+    
+    func onRemoved() {
+        NSLog("Logger removed.")
+    }
+}
+
 @UIApplicationMain
 class AppDelegate: UIResponder, UIApplicationDelegate {
 
     var window: UIWindow?
 
-
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplicationLaunchOptionsKey: Any]?) -> Bool {
         // Override point for customization after application launch.
-        KeenClient.enableLogging();
+        KeenClient.addLogSink(ExampleLogger())
+        KeenClient.setLogLevel(.verbose)
+        KeenClient.enableLogging()
         
         var client : KeenClient;
         client = KeenClient.sharedClient(withProjectID: "project_id", andWriteKey: "wk", andReadKey: "rk");
-
+        
         client.globalPropertiesBlock = {(eventCollection : String?) -> [AnyHashable: Any]? in
             return [ "GLOBALS": "YEAH WHAT SWIFT"]
         };

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ Uncompress the ZIP file for the platform you're using, and drag the folder into 
 
 #### Swift
 
-Add a header file “ProjectName-Bridging-Header.h”. In the bridging header file, add: 
+Add a header file “ProjectName-Bridging-Header.h”. In the bridging header file, add:
 
 ```objc
 // If you're using the binary
@@ -165,7 +165,7 @@ override func viewWillAppear(_ animated: Bool)
 	do {
 		try KeenClient.shared().addEvent(event, toEventCollection: "tab_views")
 	} catch _ {
-	};	
+	};
 }
 ```
 
@@ -202,10 +202,10 @@ Objective C
 Swift
 ```Swift
 
-override func viewWillAppear(animated: Bool) 
+override func viewWillAppear(animated: Bool)
 {
 	super.viewWillAppear(animated)
-        
+
 	let event = ["view_name": "first view Swift", "action": "going to"]
 	let keenProps: KeenProperties = KeenProperties()
 	keenProps.timestamp = NSDate() as Date!;
@@ -240,9 +240,9 @@ Objective C
 ```
 Swift
 ```Swift
-func applicationDidBecomeActive(application: UIApplication) 
+func applicationDidBecomeActive(application: UIApplication)
 {
-	KeenClient.shared().globalPropertiesDictionary = 
+	KeenClient.shared().globalPropertiesDictionary =
 					        ["some_standard_key" : "some_standard_value"]
 }
 ```
@@ -546,9 +546,9 @@ void (^countQueryCompleted)(NSData *, NSURLResponse *, NSError *) = ^(NSData *re
                                         JSONObjectWithData:responseData
                                         options:kNilOptions
                                         error:nil];
-    
+
     NSNumber *result = [responseDictionary objectForKey:@"result"];
-    
+
     if(error || [responseDictionary objectForKey:@"error_code"]) {
         NSLog(@"Failure! 😞 \n\n error: %@\n\n response: %@", [error localizedDescription], [responseDictionary description]);
     } else {
@@ -563,7 +563,7 @@ Swift:
 let countQueryCompleted = { (responseData: Data?, returningResponse: URLResponse?, error: Error?) -> Void in
     do {
         let responseDictionary: NSDictionary? = try JSONSerialization.jsonObject(with: responseData!, options: JSONSerialization.ReadingOptions.mutableContainers) as? NSDictionary;
-        
+
         if error != nil {
             self.resultTextView.text = "Error! 😞 \n\n error: \(error.localizedDescription)"
         } else if let errorCode = responseDictionary!.object(forKey: "error_code"),
@@ -571,7 +571,7 @@ let countQueryCompleted = { (responseData: Data?, returningResponse: URLResponse
             self.resultTextView.text = "Failure! 😞 \n\n error code: \(errorCode)\n\n message: \(errorMessage)"
         } else {
             let result: NSNumber = responseDictionary!.object(forKey: "result") as! NSNumber
-            
+
             self.resultTextView.text = "Success! 😄 \n\n result: \(result) \n\n response: \(responseDictionary!.description)"
         }
     } catch let error as NSError {
@@ -585,7 +585,7 @@ let countQueryCompleted = { (responseData: Data?, returningResponse: URLResponse
 Objective-C:
 ```objc
 KIOQuery *countQuery = [[KIOQuery alloc] initWithQuery:@"count" andPropertiesDictionary:@{@"event_collection": @"collection", @"timeframe": @"this_14_days"}];
-    
+
 [[KeenClient sharedClient] runAsyncQuery:countQuery block:countQueryCompleted];
 ```
 
@@ -603,7 +603,7 @@ KeenClient.shared().runAsyncQuery(countQuery, block: countQueryCompleted)
 Objective-C:
 ```objc
 KIOQuery *countUniqueQuery = [[KIOQuery alloc] initWithQuery:@"count_unique" andPropertiesDictionary:@{@"event_collection": @"collection", @"target_property": @"key", @"timeframe": @"this_14_days"}];
-    
+
 [[KeenClient sharedClient] runAsyncQuery:countUniqueQuery block:countQueryCompleted];
 ```
 
@@ -648,7 +648,7 @@ KIOQuery *funnelQuery = [[KIOQuery alloc] initWithQuery:@"funnel" andPropertiesD
             @"actor_property": @"user.id"},
           @{@"event_collection": @"user_completed_profile",
             @"actor_property": @"user.id"}]}];
-    
+
 [[KeenClient sharedClient] runAsyncQuery:funnelQuery block:countQueryCompleted];
 ```
 
@@ -725,11 +725,10 @@ Objective C
 
 ...
 
-// Add custom logger before enabling logging so
-// a default NSLog logger won't be created and added internally
-// Do this after calling enableLogging if you'd like 
-// the internal NSLog logger in addition to your custom logger
+// Add custom logger
 [KeenClient addLogSink:[[ExampleLogger alloc] init]];
+// Optionally, disable logging to NSLog
+[KeenClient setIsNSLogEnabled:NO];
 // Set desired log level. Only messages at or below
 // this log level are sent to the logger
 [KeenClient setLogLevel:KeenLogLevelInfo];
@@ -758,11 +757,10 @@ class ExampleLogger: KeenLogSink {
 
 ...
 
-// Add custom logger before enabling logging so
-// a default NSLog logger won't be created and added internally
-// Do this after calling enableLogging if you'd like 
-// the internal NSLog logger in addition to your custom logger
+// Add custom logger
 KeenClient.addLogSink(ExampleLogger())
+// Optionally, disable logging to NSLog
+KeenClient.setIsNSLogEnabled(false);
 // Set desired log level. Only messages at or below
 // this log level are sent to the logger
 KeenClient.setLogLevel(.verbose)
@@ -771,7 +769,6 @@ KeenClient.enableLogging()
 
 ```
 
-Note that if your own custom logger is added before `enableLogging` is called, the default NSLog logger is not enabled. If you'd like to see messages through NSLog as well, you could add your custom logger after calling `enableLogging`, since `enableLogging` creates an internal NSLog logger if no loggers have been added.
 
 
 ### FAQs


### PR DESCRIPTION
This adds extensibility hooks for SDK logging. This is important so clients have a means to collect logs for SDK failures in a production environment. This could be used, for example, with an implementation of the KeenLogSink protocol that logs using CocoaLumberJack, which would be configured with a log uploader and aggregator such as Crashlytics.

This should help diagnosis of #183 and #170 if affected customers update their apps to collect logs from the SDK at an appropriate logging level.