### PR TITLE
Fix CI error reporting.

### DIFF
--- a/bin/test.sh
+++ b/bin/test.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
-set -e
+set -e -o pipefail
 
 xcodebuild \
 	-scheme KeenClient \


### PR DESCRIPTION
CI would mistakenly report success when xcodebuild would exit with failure, but xcpretty would not. The fix is to use set -e -o pipefail to fail when any operation in the pipe fails and exit the script with that failure code. xcpretty suggests doing this under the usage section of their [readme](https://github.com/supermarin/xcpretty)