### PR TITLE
Add example apps to CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ xcode_scheme: KeenClient
 xcode_sdk: iphonesimulator9.2
 before_install:
   - gem install bundler
-  - rvm use 2.2.1
+  - rvm use 2.2.1 --install
   - brew update
   - brew outdated xctool || brew upgrade xctool
 install: bundle install --without=documentation --path ../travis_bundle_dir

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: objective-c
 cache:
   - bundler
-osx_image: xcode7.2
+osx_image: xcode8.2
 xcode_project: KeenClient.xcodeproj
 xcode_scheme: KeenClient
 xcode_sdk: iphonesimulator9.2

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,8 @@ xcode_project: KeenClient.xcodeproj
 xcode_scheme: KeenClient
 xcode_sdk: iphonesimulator9.2
 before_install:
-  - gem install bundler
   - rvm use 2.2.1 --install
+  - gem install bundler
   - brew update
   - brew outdated xctool || brew upgrade xctool
 install: bundle install --without=documentation --path ../travis_bundle_dir

--- a/KeenClient.xcodeproj/xcshareddata/xcschemes/KeenClientExample.xcscheme
+++ b/KeenClient.xcodeproj/xcshareddata/xcschemes/KeenClientExample.xcscheme
@@ -1,0 +1,91 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "0730"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "0105EE5C14E9A4940048D871"
+               BuildableName = "KeenClientExample.app"
+               BlueprintName = "KeenClientExample"
+               ReferencedContainer = "container:KeenClientExample/KeenClientExample.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+      </Testables>
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "0105EE5C14E9A4940048D871"
+            BuildableName = "KeenClientExample.app"
+            BlueprintName = "KeenClientExample"
+            ReferencedContainer = "container:KeenClientExample/KeenClientExample.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "0105EE5C14E9A4940048D871"
+            BuildableName = "KeenClientExample.app"
+            BlueprintName = "KeenClientExample"
+            ReferencedContainer = "container:KeenClientExample/KeenClientExample.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "0105EE5C14E9A4940048D871"
+            BuildableName = "KeenClientExample.app"
+            BlueprintName = "KeenClientExample"
+            ReferencedContainer = "container:KeenClientExample/KeenClientExample.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/KeenClient.xcodeproj/xcshareddata/xcschemes/KeenSwiftClientExample.xcscheme
+++ b/KeenClient.xcodeproj/xcshareddata/xcschemes/KeenSwiftClientExample.xcscheme
@@ -1,0 +1,101 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "0730"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "A58E0BDE1AF85F3C00DF2B71"
+               BuildableName = "KeenSwiftClientExample.app"
+               BlueprintName = "KeenSwiftClientExample"
+               ReferencedContainer = "container:KeenSwiftClientExample/KeenSwiftClientExample.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "A58E0BF51AF85F3C00DF2B71"
+               BuildableName = "KeenSwiftClientExampleTests.xctest"
+               BlueprintName = "KeenSwiftClientExampleTests"
+               ReferencedContainer = "container:KeenSwiftClientExample/KeenSwiftClientExample.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "A58E0BDE1AF85F3C00DF2B71"
+            BuildableName = "KeenSwiftClientExample.app"
+            BlueprintName = "KeenSwiftClientExample"
+            ReferencedContainer = "container:KeenSwiftClientExample/KeenSwiftClientExample.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "A58E0BDE1AF85F3C00DF2B71"
+            BuildableName = "KeenSwiftClientExample.app"
+            BlueprintName = "KeenSwiftClientExample"
+            ReferencedContainer = "container:KeenSwiftClientExample/KeenSwiftClientExample.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "A58E0BDE1AF85F3C00DF2B71"
+            BuildableName = "KeenSwiftClientExample.app"
+            BlueprintName = "KeenSwiftClientExample"
+            ReferencedContainer = "container:KeenSwiftClientExample/KeenSwiftClientExample.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/KeenClientExample/KeenClientExample.xcodeproj/project.pbxproj
+++ b/KeenClientExample/KeenClientExample.xcodeproj/project.pbxproj
@@ -50,8 +50,8 @@
 		012E8A5F1672C30C0021F6FA /* CoreLocation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreLocation.framework; path = System/Library/Frameworks/CoreLocation.framework; sourceTree = SDKROOT; };
 		015D307E1822DE7D00F8735B /* Default-568h@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "Default-568h@2x.png"; sourceTree = "<group>"; };
 		01F90AF514F36C2800DD3DE2 /* KeenClient.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = KeenClient.h; path = ../KeenClient/KeenClient.h; sourceTree = "<group>"; };
-		3E0EC09D1B11701B00195A42 /* third.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; name = third.png; path = "../../../../Github/KeenClient-iOS/KeenClientExample/KeenClientExample/third.png"; sourceTree = "<group>"; };
-		3E0EC09E1B11701B00195A42 /* third@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; name = "third@2x.png"; path = "../../../../Github/KeenClient-iOS/KeenClientExample/KeenClientExample/third@2x.png"; sourceTree = "<group>"; };
+		3E0EC09D1B11701B00195A42 /* third.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = third.png; sourceTree = "<group>"; };
+		3E0EC09E1B11701B00195A42 /* third@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "third@2x.png"; sourceTree = "<group>"; };
 		3E0EC0A71B11740900195A42 /* ThirdViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ThirdViewController.h; sourceTree = "<group>"; };
 		3E0EC0A81B11740900195A42 /* ThirdViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ThirdViewController.m; sourceTree = "<group>"; };
 		3E0EC0A91B11740900195A42 /* ThirdViewController.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = ThirdViewController.xib; sourceTree = "<group>"; };

--- a/bin/test.sh
+++ b/bin/test.sh
@@ -8,3 +8,17 @@ xcodebuild \
 	-enableCodeCoverage YES \
   ONLY_ACTIVE_ARCH=NO \
 	clean test | xcpretty --color
+
+xcodebuild \
+	-scheme KeenSwiftClientExample \
+	-sdk iphonesimulator \
+	-destination 'platform=iOS Simulator,name=iPhone 6,OS=9.2' \
+  ONLY_ACTIVE_ARCH=NO \
+	clean build | xcpretty --color
+
+xcodebuild \
+	-scheme KeenClientExample \
+	-sdk iphonesimulator \
+	-destination 'platform=iOS Simulator,name=iPhone 6,OS=9.2' \
+  ONLY_ACTIVE_ARCH=NO \
+	clean build | xcpretty --color

--- a/bin/test.sh
+++ b/bin/test.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
-set -e
+set -e -o pipefail
 
 xcodebuild \
 	-scheme KeenClient \


### PR DESCRIPTION
Example apps weren't being built by CI, so add them.

KeenClientExample wasn't building, so fix that, too.