### PR TITLE
Fix tests

### DIFF
--- a/KeenClient/KIODBStore.m
+++ b/KeenClient/KIODBStore.m
@@ -793,7 +793,8 @@
             return;
         }
         
-        if (keen_io_sqlite3_step(get_query_stmt) == SQLITE_ROW) {
+        int result = keen_io_sqlite3_step(get_query_stmt);
+        if (SQLITE_ROW == result) {
             // Fetch data out the statement
             query = [NSMutableDictionary dictionary];
             
@@ -815,7 +816,9 @@
             [query setObject:data forKey:@"queryData"];
             [query setObject:queryType forKey:@"queryType"];
             [query setObject:attempts forKey:@"attempts"];
-        } else {
+        } else if (SQLITE_DONE != result) {
+            // SQLITE_DONE just means there weren't any results, which isn't a db error.
+            // If we got anything else, we treat it as an error here.
             [self handleSQLiteFailure:@"find query"];
             return;
         }

--- a/KeenClient/KIONetwork.m
+++ b/KeenClient/KIONetwork.m
@@ -98,12 +98,12 @@
 }
 
 - (BOOL)hasQueryReachedMaxAttempts:(KIOQuery*)keenQuery withProjectID:(NSString*)projectID {
-    return [KIODBStore.sharedInstance hasQueryWithMaxAttempts:[keenQuery convertQueryToData]
-                                                    queryType:keenQuery.queryType
-                                                   collection:[keenQuery.propertiesDictionary objectForKey:@"event_collection"]
-                                                    projectID:projectID
-                                                  maxAttempts:self.maxQueryAttempts
-                                                     queryTTL:self.queryTTL];
+    return [self.store hasQueryWithMaxAttempts:[keenQuery convertQueryToData]
+                                     queryType:keenQuery.queryType
+                                    collection:[keenQuery.propertiesDictionary objectForKey:@"event_collection"]
+                                     projectID:projectID
+                                   maxAttempts:self.maxQueryAttempts
+                                      queryTTL:self.queryTTL];
 }
 
 # pragma mark Sync methods
@@ -137,18 +137,18 @@
                                kKeenServerAddress, kKeenApiVersion, projectID, keenQuery.queryType];
         KCLog(@"Sending request to: %@", urlString);
 
-        NSMutableURLRequest* request = [KIONetwork.sharedInstance createRequestWithUrl:urlString
-                                                                               andBody:[keenQuery convertQueryToData]
-                                                                                andKey:readKey];
+        NSMutableURLRequest* request = [self createRequestWithUrl:urlString
+                                                          andBody:[keenQuery convertQueryToData]
+                                                           andKey:readKey];
 
-        [KIONetwork.sharedInstance executeRequest:request
-                                completionHandler:^(NSData* data, NSURLResponse* response, NSError* error) {
-                                    [self handleQueryAPIResponse:response
-                                                         andData:data
-                                                        andQuery:keenQuery
-                                                    andProjectID:projectID];
-                                    completionHandler(data, response, error);
-                                }];
+        [self executeRequest:request
+           completionHandler:^(NSData* data, NSURLResponse* response, NSError* error) {
+            [self handleQueryAPIResponse:response
+                                 andData:data
+                                andQuery:keenQuery
+                            andProjectID:projectID];
+            completionHandler(data, response, error);
+        }];
     }
 }
 
@@ -206,12 +206,12 @@
         return;
     }
 
-    NSMutableURLRequest* request = [KIONetwork.sharedInstance createRequestWithUrl:urlString
-                                                                           andBody:multiAnalysisData
-                                                                            andKey:readKey];
+    NSMutableURLRequest* request = [self createRequestWithUrl:urlString
+                                                      andBody:multiAnalysisData
+                                                       andKey:readKey];
 
-    [KIONetwork.sharedInstance executeRequest:request
-                            completionHandler:completionHandler];
+    [self executeRequest:request
+       completionHandler:completionHandler];
 }
 
 

--- a/KeenClientTests/KeenClientTests.m
+++ b/KeenClientTests/KeenClientTests.m
@@ -501,7 +501,7 @@ NSString* kDefaultReadKey = @"rk";
                  andResponseData:(NSData*)responseData
              andRequestValidator:(BOOL (^)(id requestObject))requestValidator {
     // Mock the NSURLSession to be used for the request
-    id urlSessionMock = [OCMockObject partialMockForObject:[NSURLSession sharedSession]];
+    id urlSessionMock = [OCMockObject partialMockForObject:[[NSURLSession alloc] init]];
 
     // Set up fake response data and request validation
     if (nil != requestValidator) {
@@ -581,11 +581,19 @@ NSString* kDefaultReadKey = @"rk";
 # pragma mark - test upload
 
 -(void)testUploadWithNoEvents {
+    XCTestExpectation* uploadFinishedBlockCalled = [self expectationWithDescription:@"Upload should finish."];
+    
     id mock = [self createClientWithResponseData:nil andStatusCode:HTTPCode200OK];
 
-    [mock uploadWithFinishedBlock:nil];
+    [mock uploadWithFinishedBlock:^{
+        [uploadFinishedBlockCalled fulfill];
+    }];
 
-    XCTAssertTrue([KIODBStore.sharedInstance getTotalEventCountWithProjectID:[mock projectID]] == 0, @"Upload method should return with message Request data is empty.");
+    [self waitForExpectationsWithTimeout:_asyncTimeInterval handler:^(NSError * _Nullable error) {
+        XCTAssertEqual([KIODBStore.sharedInstance getTotalEventCountWithProjectID:[mock projectID]],
+                       0,
+                       @"Upload method should return with message Request data is empty.");
+    }];
 }
 
 - (void)testUploadSuccess {
@@ -1472,21 +1480,45 @@ NSString* kDefaultReadKey = @"rk";
 }
 
 - (void)testUploadMultipleTimes {
+    XCTestExpectation* uploadFinishedBlockCalled1 = [self expectationWithDescription:@"Upload 1 should run to completion."];
+    XCTestExpectation* uploadFinishedBlockCalled2 = [self expectationWithDescription:@"Upload 2 should run to completion."];
+    XCTestExpectation* uploadFinishedBlockCalled3 = [self expectationWithDescription:@"Upload 3 should run to completion."];
+    
     KeenClient *client = [KeenClient sharedClientWithProjectID:kDefaultProjectID andWriteKey:kDefaultWriteKey andReadKey:kDefaultReadKey];
     client.isRunningTests = YES;
 
-    [client uploadWithFinishedBlock:nil];
-    [client uploadWithFinishedBlock:nil];
-    [client uploadWithFinishedBlock:nil];
+    [client uploadWithFinishedBlock:^{
+        [uploadFinishedBlockCalled1 fulfill];
+    }];
+    [client uploadWithFinishedBlock:^{
+        [uploadFinishedBlockCalled2 fulfill];
+    }];
+    [client uploadWithFinishedBlock:^ {
+        [uploadFinishedBlockCalled3 fulfill];
+    }];
+    
+    [self waitForExpectationsWithTimeout:_asyncTimeInterval handler:nil];
 }
 
 - (void)testUploadMultipleTimesInstanceClient {
+    XCTestExpectation* uploadFinishedBlockCalled1 = [self expectationWithDescription:@"Upload 1 should run to completion."];
+    XCTestExpectation* uploadFinishedBlockCalled2 = [self expectationWithDescription:@"Upload 2 should run to completion."];
+    XCTestExpectation* uploadFinishedBlockCalled3 = [self expectationWithDescription:@"Upload 3 should run to completion."];
+
     KeenClient *client = [[KeenClient alloc] initWithProjectID:kDefaultProjectID andWriteKey:kDefaultWriteKey andReadKey:kDefaultReadKey];
     client.isRunningTests = YES;
 
-    [client uploadWithFinishedBlock:nil];
-    [client uploadWithFinishedBlock:nil];
-    [client uploadWithFinishedBlock:nil];
+    [client uploadWithFinishedBlock:^{
+        [uploadFinishedBlockCalled1 fulfill];
+    }];
+    [client uploadWithFinishedBlock:^{
+        [uploadFinishedBlockCalled2 fulfill];
+    }];
+    [client uploadWithFinishedBlock:^ {
+        [uploadFinishedBlockCalled3 fulfill];
+    }];
+    
+    [self waitForExpectationsWithTimeout:_asyncTimeInterval handler:nil];
 }
 
 - (void)testMigrateFSEvents {
@@ -1961,9 +1993,9 @@ NSString* kDefaultReadKey = @"rk";
 
 - (void)testSdkTrackingHeadersOnMultiAnalysis {
     KeenClient* client = [self createClientWithResponseData:@{@"result": @{@"query1": @10, @"query2": @1}}
-                                   andStatusCode:HTTPCode200OK
-                             andNetworkConnected:@YES
-                             andRequestValidator:^BOOL(id obj) {
+                                              andStatusCode:HTTPCode200OK
+                                        andNetworkConnected:@YES
+                                        andRequestValidator:^BOOL(id obj) {
         [self validateSdkVersionHeaderFieldForRequest:obj];
         return @YES;
     }];
@@ -1971,15 +2003,15 @@ NSString* kDefaultReadKey = @"rk";
     // Get the mock url session. We'll check the request it gets passed by sendEvents for the version header
     id urlSessionMock = client.network.urlSession;
 
-    KIOQuery *countQuery = [[KIOQuery alloc] initWithQuery:@"count"
+    KIOQuery* countQuery = [[KIOQuery alloc] initWithQuery:@"count"
                                    andPropertiesDictionary:@{@"event_collection": @"event_collection"}];
 
-    KIOQuery *averageQuery = [[KIOQuery alloc] initWithQuery:@"count_unique"
+    KIOQuery* averageQuery = [[KIOQuery alloc] initWithQuery:@"count_unique"
                                      andPropertiesDictionary:@{@"event_collection": @"event_collection", @"target_property": @"something"}];
 
     XCTestExpectation* responseArrived = [self expectationWithDescription:@"response of async request has arrived"];
     [client runMultiAnalysisWithQueries:@[countQuery, averageQuery]
-                      completionHandler:^(NSData *queryResponseData, NSURLResponse *response, NSError *error) {
+                      completionHandler:^(NSData* queryResponseData, NSURLResponse* response, NSError* error) {
         // Check for the sdk version header
         [urlSessionMock verify];
 


### PR DESCRIPTION
Properly reference dependency injected version of KIODBStore and reference self within KIONetwork. 

Fix another false positive DB failure which would cause #183 to be observed more frequently, since trying to get a non-existent query from the db would be handled as a db error and close the db.

Fix a few async tests that weren't waiting for async code to complete.

Likely to fix #192.