### PR TITLE
3.6.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,13 +3,23 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
 
-## [Unreleased] - Unreleased
+## [3.6.0] - 2017-04-05
 ### Added
 - Extensibility hooks for custom logging implementations.
 
+### Changed
+- Updated Travis CI image to Xcode 8.2
+- Enabled bundler gem caching for faster CI builds
+- Added example apps to CI build
+
 ### Fixed
-- Fixed bug where KIODBStore would close and reopen db when performing any query, which could contribute to experiencing issue #183 more often.
+- Fixed bug where KIODBStore would close and reopen DB when performing any query, which could contribute to experiencing issue #183 more often.
+- Fixed a similar issue where KIODBStore would close and reopen the DB when attempting to get a query that wasn't in the DB, also leading to more observations of #183.
 - Fixed unit test setup issues leading to non-deterministic test failures.
+- Fixed unit test issues where async tests weren't waiting for completion of async operations.
+- Fixed issue #156, which could lead to duplicate event uploads.
+- Fixed Travis CI issue where test.sh wouldn't correctly report a build failure.
+- Fixed build break in example Obj-C app
 
 ## [3.5.7] - 2017-03-03
 ### Changed

--- a/KeenClient.podspec
+++ b/KeenClient.podspec
@@ -10,7 +10,8 @@ Pod::Spec.new do |spec|
     'Daniel Kador'    => 'dan@keen.io',
     'Terry Horner'    => 'terry@keen.io',
     'Claire Young'    => 'claire@keen.io',
-    'Heitor Sergent'  => 'heitor@keen.io'
+    'Heitor Sergent'  => 'heitor@keen.io',
+    'Brian Baumhover' => 'b.baumhover@gmail.com'
   }
 
   spec.summary      = 'Keen iOS client library.'

--- a/KeenClient.podspec
+++ b/KeenClient.podspec
@@ -1,18 +1,18 @@
 Pod::Spec.new do |spec|
   spec.name         = 'KeenClient'
-  spec.version      = '3.5.7'
+  spec.version      = '3.6.0'
   spec.license      = { :type => 'MIT' }
   spec.ios.deployment_target = '6.0'
   spec.osx.deployment_target = '10.9'
   spec.homepage     = 'https://github.com/keenlabs/KeenClient-iOS'
-  
-  spec.authors      = { 
+
+  spec.authors      = {
     'Daniel Kador'    => 'dan@keen.io',
     'Terry Horner'    => 'terry@keen.io',
     'Claire Young'    => 'claire@keen.io',
     'Heitor Sergent'  => 'heitor@keen.io'
   }
-  
+
   spec.summary      = 'Keen iOS client library.'
   spec.description	= <<-DESC
                       The Keen client is designed to be simple to develop with, yet incredibly flexible.  Our goal is to let you decide what events are important to you, use your own vocabulary to describe them, and decide when you want to send them to Keen service.
@@ -22,7 +22,7 @@ Pod::Spec.new do |spec|
   spec.public_header_files = 'KeenClient/*.h'
   spec.frameworks   = 'CoreLocation'
   spec.requires_arc = true
-  
+
   spec.subspec 'keen_sqlite' do |ks|
     ks.source_files = 'Library/sqlite-amalgamation/*.{h,c}'
     ks.private_header_files = 'Library/sqlite-amalgamation/*.h'

--- a/KeenClient/KeenClient.h
+++ b/KeenClient/KeenClient.h
@@ -385,7 +385,8 @@ NS_SWIFT_NAME(addLogSink(_:));
 /**
  Remove a log sink
  */
-+ (void)removeLogSink:(id<KeenLogSink>)sink;
++ (void)removeLogSink:(id<KeenLogSink>)sink
+NS_SWIFT_NAME(removeLogSink(_:));
 
 /**
  Set the verbosity of logging that will be sent to the sinks.

--- a/KeenClient/KeenConstants.h
+++ b/KeenClient/KeenConstants.h
@@ -8,7 +8,7 @@
 
 #import <Foundation/Foundation.h>
 
-#define kKeenSdkVersion @"3.5.7"
+#define kKeenSdkVersion @"3.6.0"
 
 extern NSString * const kKeenServerAddress;
 extern NSString * const kKeenApiVersion;

--- a/KeenClientFramework/Info.plist
+++ b/KeenClientFramework/Info.plist
@@ -15,11 +15,11 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>3.5.7</string>
+	<string>3.6.0</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>
-	<string>3.5.7</string>
+	<string>3.6.0</string>
 	<key>NSPrincipalClass</key>
 	<string></string>
 </dict>


### PR DESCRIPTION
3.6.0 release

Update CHANGELOG.md to reflect all changes since 3.5.7.
Update version in podspec.
Update framework bundle version.
Update internal SDK version string.

Finally, fix slight issue with the automatically generated swift name for removeLogSink:.