### PR TITLE
Set deploy target to iOS 8 for unit tests to appease Xcode 8.3

### DIFF
--- a/KeenClient.xcodeproj/project.pbxproj
+++ b/KeenClient.xcodeproj/project.pbxproj
@@ -969,7 +969,7 @@
 				"GCC_PREPROCESSOR_DEFINITIONS[arch=*]" = "$(inherited)";
 				HEADER_SEARCH_PATHS = "${PROJECT_DIR}/**";
 				INFOPLIST_FILE = "KeenClientTests/KeenClientTests-Info.plist";
-				IPHONEOS_DEPLOYMENT_TARGET = 7.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				LIBRARY_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(SRCROOT)/Library",
@@ -994,7 +994,7 @@
 				GCC_PREFIX_HEADER = "$(PROJECT_DIR)/KeenClient/KeenClient-Prefix.pch";
 				HEADER_SEARCH_PATHS = "${PROJECT_DIR}/**";
 				INFOPLIST_FILE = "KeenClientTests/KeenClientTests-Info.plist";
-				IPHONEOS_DEPLOYMENT_TARGET = 7.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				LIBRARY_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(SRCROOT)/Library",


### PR DESCRIPTION
The XCTest framework included with Xcode 8.3 is a dynamic framework, which aren't supported until iOS 8. This doesn't affect requirements for library clients.

Fixes #204.