### PR TITLE
Update Travis to use latest Xcode image, latest iOS version, and speed up build

### DIFF
--- a/.slather.yml
+++ b/.slather.yml
@@ -1,5 +1,7 @@
 coverage_service: coveralls
+workspace: ./KeenClient.xcworkspace
 xcodeproj: ./KeenClient.xcodeproj
+scheme: KeenClient
 ignore:
   - KeenClientTests/*
   - Library/*

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,9 +7,6 @@ xcode_sdk: iphonesimulator10.3
 before_install:
   - gem install bundler
   - rvm use 2.3.0
-  - brew update
-  - brew outdated xctool || brew upgrade xctool
 after_success:
-  - bundle exec slather coverage -s --scheme KeenClient KeenClient.xcodeproj
   - bundle exec slather
 script: ./bin/test.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -38,5 +38,12 @@ before_install:
 
 script: ./bin/test.sh
 
-after_success:
-  - bundle exec slather
+after_success: |
+  case "$XCODEBUILD_ACTION" in
+    test)
+      bundle exec slather
+      ;;
+    *)
+      echo "Not slathering."
+      ;;
+  esac

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ cache: bundler
 osx_image: xcode8.3
 xcode_project: KeenClient.xcodeproj
 xcode_scheme: KeenClient
-xcode_sdk: iphonesimulator9.2
+xcode_sdk: iphonesimulator10.3
 before_install:
   - gem install bundler
   - rvm use 2.3.0

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,12 @@
 language: objective-c
 cache: bundler
-osx_image: xcode8.2
+osx_image: xcode8.3
 xcode_project: KeenClient.xcodeproj
 xcode_scheme: KeenClient
 xcode_sdk: iphonesimulator9.2
 before_install:
   - gem install bundler
-  - rvm use 2.2.1 --install
+  - rvm use 2.3.0
   - brew update
   - brew outdated xctool || brew upgrade xctool
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,42 @@
 language: objective-c
+
 cache: bundler
+
 osx_image: xcode8.3
-xcode_project: KeenClient.xcodeproj
-xcode_scheme: KeenClient
+
+xcode_workspace: KeenClient.xcworkspace
+xcode_scheme:
+  - KeenClientFramework
+  - KeenSwiftClientExample
+  - KeenClientExample
 xcode_sdk: iphonesimulator10.3
+env:
+  - XCODEBUILD_PLATFORM='iOS Simulator' XCODEBUILD_SIM_OS=10.3 XCODEBUILD_DEVICE='iPhone 6' XCODEBUILD_ACTION=build
+
+matrix:
+  include:
+    - xcode_scheme: KeenClient
+      xcode_sdk: iphonesimulator10.3
+      env:
+        - XCODEBUILD_PLATFORM='iOS Simulator' XCODEBUILD_SIM_OS=10.3 XCODEBUILD_DEVICE='iPhone 6' XCODEBUILD_ACTION=test
+    - xcode_scheme: KeenClient
+      xcode_sdk: iphonesimulator10.3
+      env:
+        - XCODEBUILD_PLATFORM='iOS Simulator' XCODEBUILD_SIM_OS=9.3 XCODEBUILD_DEVICE='iPhone 6' XCODEBUILD_ACTION=test
+    - xcode_scheme: KeenClient
+      xcode_sdk: iphonesimulator10.3
+      env:
+        - XCODEBUILD_PLATFORM='iOS Simulator' XCODEBUILD_SIM_OS=8.4 XCODEBUILD_DEVICE='iPhone 6' XCODEBUILD_ACTION=test
+    - xcode_scheme: KeenClient-Cocoa
+      xcode_sdk: macosx10.12
+      env:
+        - XCODEBUILD_PLATFORM='OS X' XCODEBUILD_ACTION=build
+
 before_install:
   - gem install bundler
   - rvm use 2.3.0
+
+script: ./bin/test.sh
+
 after_success:
   - bundle exec slather
-script: ./bin/test.sh

--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,5 @@
 source 'https://rubygems.org'
-#ruby='2.2.1'
-ruby '2.2.1'
+ruby '2.3.0'
 
 gem 'slather'
 gem 'xcpretty'

--- a/KeenClient.xcodeproj/xcshareddata/xcschemes/KeenClient-Cocoa.xcscheme
+++ b/KeenClient.xcodeproj/xcshareddata/xcschemes/KeenClient-Cocoa.xcscheme
@@ -1,0 +1,80 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "0730"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "1296396219C10AD200B2B653"
+               BuildableName = "libKeenClient-Cocoa.a"
+               BlueprintName = "KeenClient-Cocoa"
+               ReferencedContainer = "container:KeenClient.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+      </Testables>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "1296396219C10AD200B2B653"
+            BuildableName = "libKeenClient-Cocoa.a"
+            BlueprintName = "KeenClient-Cocoa"
+            ReferencedContainer = "container:KeenClient.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "1296396219C10AD200B2B653"
+            BuildableName = "libKeenClient-Cocoa.a"
+            BlueprintName = "KeenClient-Cocoa"
+            ReferencedContainer = "container:KeenClient.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/bin/simulate_travis.sh
+++ b/bin/simulate_travis.sh
@@ -1,0 +1,36 @@
+#!/bin/bash --login
+
+SCRIPTPATH=$(dirname $0)
+
+# Do a travis-like validation build and test
+
+gem install bundler
+rvm use 2.3.0
+
+export TRAVIS_XCODE_WORKSPACE="$SCRIPTPATH/../KeenClient.xcworkspace"
+export TRAVIS_XCODE_SDK=iphonesimulator10.3
+export XCODEBUILD_PLATFORM='iOS Simulator'
+export XCODEBUILD_SIM_OS=10.3
+export XCODEBUILD_DEVICE='iPhone 6'
+export XCODEBUILD_ACTION=build
+
+BUILD_SCRIPT="$SCRIPTPATH/test.sh"
+
+export TRAVIS_XCODE_SCHEME=KeenClientFramework
+$BUILD_SCRIPT
+
+export TRAVIS_XCODE_SCHEME=KeenSwiftClientExample
+$BUILD_SCRIPT
+
+export TRAVIS_XCODE_SCHEME=KeenClientExample
+$BUILD_SCRIPT
+
+export TRAVIS_XCODE_SCHEME=KeenClient
+export XCODEBUILD_ACTION=test
+$BUILD_SCRIPT
+
+export TRAVIS_XCODE_SCHEME=KeenClient-Cocoa
+export TRAVIS_XCODE_SDK='macosx10.12'
+export XCODEBUILD_PLATFORM='OS X'
+export XCODEBUILD_ACTION=build
+$BUILD_SCRIPT

--- a/bin/test.sh
+++ b/bin/test.sh
@@ -4,27 +4,24 @@ set -e -o pipefail
 xcodebuild \
 	-scheme KeenSwiftClientExample \
 	-sdk iphonesimulator \
-	-destination 'platform=iOS Simulator,name=iPhone 6,OS=9.2' \
   ONLY_ACTIVE_ARCH=NO \
 	clean build | bundle exec xcpretty --color
 
 xcodebuild \
 	-scheme KeenClientExample \
 	-sdk iphonesimulator \
-	-destination 'platform=iOS Simulator,name=iPhone 6,OS=9.2' \
   ONLY_ACTIVE_ARCH=NO \
 	clean build | bundle exec xcpretty --color
 
 xcodebuild \
 	-scheme KeenClientFramework \
 	-sdk iphonesimulator \
-	-destination 'platform=iOS Simulator,name=iPhone 6,OS=9.2' \
   ONLY_ACTIVE_ARCH=NO \
 	clean build | bundle exec xcpretty --color
 
 xcodebuild \
 	-scheme KeenClient \
 	-sdk iphonesimulator \
-	-destination 'platform=iOS Simulator,name=iPhone 6,OS=9.2' \
+	-destination 'platform=iOS Simulator,name=iPhone 6,OS=10.3' \
   ONLY_ACTIVE_ARCH=NO \
 	clean test | bundle exec xcpretty --color

--- a/bin/test.sh
+++ b/bin/test.sh
@@ -1,27 +1,17 @@
 #!/bin/sh
 set -e -o pipefail
 
-xcodebuild \
-	-scheme KeenSwiftClientExample \
-	-sdk iphonesimulator \
-  ONLY_ACTIVE_ARCH=NO \
-	clean build | bundle exec xcpretty --color
+if [[ "$XCODEBUILD_PLATFORM" == "iOS Simulator" ]]; then
+	# iOS build
+	XCODEBUILD_DESTINATION="platform=$XCODEBUILD_PLATFORM,OS=$XCODEBUILD_SIM_OS,name=$XCODEBUILD_DEVICE"
+else
+  # OS X build
+	XCODEBUILD_DESTINATION="platform=$XCODEBUILD_PLATFORM"
+fi
 
 xcodebuild \
-	-scheme KeenClientExample \
-	-sdk iphonesimulator \
-  ONLY_ACTIVE_ARCH=NO \
-	clean build | bundle exec xcpretty --color
-
-xcodebuild \
-	-scheme KeenClientFramework \
-	-sdk iphonesimulator \
-  ONLY_ACTIVE_ARCH=NO \
-	clean build | bundle exec xcpretty --color
-
-xcodebuild \
-	-scheme KeenClient \
-	-sdk iphonesimulator \
-	-destination 'platform=iOS Simulator,name=iPhone 6,OS=10.3' \
-  ONLY_ACTIVE_ARCH=NO \
-	clean test | bundle exec xcpretty --color
+	-workspace $TRAVIS_XCODE_WORKSPACE \
+	-scheme $TRAVIS_XCODE_SCHEME \
+	-sdk $TRAVIS_XCODE_SDK \
+	-destination "$XCODEBUILD_DESTINATION" \
+	ONLY_ACTIVE_ARCH=NO clean $XCODEBUILD_ACTION | bundle exec xcpretty --color


### PR DESCRIPTION
- Update the Travis CI build to use the latest Xcode 8.3 image.
- Use the latest version of ruby included in the image. This way it doesn't need to be downloaded and that speeds up the build.
- Deploy using a simulator with the current version of iOS.
- Remove redundant and non-deterministic brew update and upgrade xctool commands that are currently just slowing down the build.
- Remove code coverage output that had been previously added for debugging purposes as coveralls seems to be giving reasonable results now.
- Remove unused simulator target parameters from xcodebuild build-only commands.