### PR TITLE
Make interface additions for #203 while maintaining minor release compatibility.

### DIFF
--- a/KeenClient/KeenClient.h
+++ b/KeenClient/KeenClient.h
@@ -314,7 +314,7 @@ typedef void (^AnalysisCompletionBlock)(NSData *, NSURLResponse *, NSError *);
  See detailed documentation here: https://keen.io/docs/api/#analyses
 
  @param keenQuery The KIOQuery object containing the information about the query.
- @param completion The block to be executed once querying is finished. It receives an NSData object containing the query results, and an NSURLResponse and NSError objects.
+ @param completionHandler The block to be executed once querying is finished. It receives an NSData object containing the query results, and an NSURLResponse and NSError objects.
  */
 - (void)runAsyncQuery:(KIOQuery *)keenQuery completionHandler:(AnalysisCompletionBlock)completionHandler;
 
@@ -335,7 +335,7 @@ typedef void (^AnalysisCompletionBlock)(NSData *, NSURLResponse *, NSError *);
  See detailed documentation here: https://keen.io/docs/api/#multi-analysis
 
  @param keenQueries The NSArray object containing multiple KIOQuery objects. They must all contain the same value for the event_collection property.
- @param completion The block to be executed once querying is finished. It receives an NSData object containing the query results, and an NSURLResponse and NSError objects.
+ @param completionHandler The block to be executed once querying is finished. It receives an NSData object containing the query results, and an NSURLResponse and NSError objects.
  */
 - (void)runAsyncMultiAnalysisWithQueries:(NSArray *)keenQueries completionHandler:(AnalysisCompletionBlock)completionHandler;
 
@@ -345,9 +345,8 @@ typedef void (^AnalysisCompletionBlock)(NSData *, NSURLResponse *, NSError *);
  This method is only used for testing.
 
  @param keenQuery The KIOQuery object containing the information about the query.
- @param returningResponse The NSURLResponse for the query.
- @param error The NSError (if any) for the query.
- */
+ @param completionHandler The block to be executed once querying is finished. It receives an NSData object containing the query results, and an NSURLResponse and NSError objects.
+  */
 - (void)runQuery:(KIOQuery *)keenQuery completionHandler:(AnalysisCompletionBlock)completionHandler
     DEPRECATED_MSG_ATTRIBUTE("use runAsyncQuery:completionHandler: instead.");
 
@@ -357,9 +356,8 @@ typedef void (^AnalysisCompletionBlock)(NSData *, NSURLResponse *, NSError *);
  This method is only used for testing.
 
  @param keenQueries The NSArray object containing multiple KIOQuery objects. They must all contain the same value for the event_collection property.
- @param returningResponse The NSURLResponse for the query.
- @param error The NSError (if any) for the query.
- */
+ @param completionHandler The block to be executed once querying is finished. It receives an NSData object containing the query results, and an NSURLResponse and NSError objects.
+  */
 - (void)runMultiAnalysisWithQueries:(NSArray *)keenQueries completionHandler:(AnalysisCompletionBlock)completionHandler
     DEPRECATED_MSG_ATTRIBUTE("use runAsyncMultiAnalysisWithQueries:completionHandler: instead.");
 

--- a/KeenClient/KeenClient.h
+++ b/KeenClient/KeenClient.h
@@ -306,7 +306,7 @@ typedef void (^AnalysisCompletionBlock)(NSData *, NSURLResponse *, NSError *);
  @param block The block to be executed once querying is finished. It receives an NSData object containing the query results, and an NSURLResponse and NSError objects.
  */
 - (void)runAsyncQuery:(KIOQuery *)keenQuery block:(AnalysisCompletionBlock)block
-DEPRECATED_MSG_ATTRIBUTE("it has been renamed to runQuery:withCompletion:");
+DEPRECATED_MSG_ATTRIBUTE("it has been renamed to runAsyncQuery:completionHandler:");
 
 /**
  Runs an asynchronous query.
@@ -316,7 +316,7 @@ DEPRECATED_MSG_ATTRIBUTE("it has been renamed to runQuery:withCompletion:");
  @param keenQuery The KIOQuery object containing the information about the query.
  @param completion The block to be executed once querying is finished. It receives an NSData object containing the query results, and an NSURLResponse and NSError objects.
  */
-- (void)runAsyncQuery:(KIOQuery *)keenQuery withCompletion:(AnalysisCompletionBlock)completion;
+- (void)runAsyncQuery:(KIOQuery *)keenQuery completionHandler:(AnalysisCompletionBlock)completionHandler;
 
 /**
  Runs an asynchronous multi-analysis query.
@@ -327,7 +327,7 @@ DEPRECATED_MSG_ATTRIBUTE("it has been renamed to runQuery:withCompletion:");
  @param block The block to be executed once querying is finished. It receives an NSData object containing the query results, and an NSURLResponse and NSError objects.
  */
 - (void)runAsyncMultiAnalysisWithQueries:(NSArray *)keenQueries block:(AnalysisCompletionBlock)block
-DEPRECATED_MSG_ATTRIBUTE("it has been renamed to runAsyncMultiAnalysisWithQueries:withCompletion:");
+DEPRECATED_MSG_ATTRIBUTE("it has been renamed to runAsyncMultiAnalysisWithQueries:completionHandler:");
 
 /**
  Runs an asynchronous multi-analysis query.
@@ -337,7 +337,7 @@ DEPRECATED_MSG_ATTRIBUTE("it has been renamed to runAsyncMultiAnalysisWithQuerie
  @param keenQueries The NSArray object containing multiple KIOQuery objects. They must all contain the same value for the event_collection property.
  @param completion The block to be executed once querying is finished. It receives an NSData object containing the query results, and an NSURLResponse and NSError objects.
  */
-- (void)runAsyncMultiAnalysisWithQueries:(NSArray *)keenQueries withCompletion:(AnalysisCompletionBlock)completion;
+- (void)runAsyncMultiAnalysisWithQueries:(NSArray *)keenQueries completionHandler:(AnalysisCompletionBlock)completionHandler;
 
 /**
  Runs a synchronous query.
@@ -349,7 +349,7 @@ DEPRECATED_MSG_ATTRIBUTE("it has been renamed to runAsyncMultiAnalysisWithQuerie
  @param error The NSError (if any) for the query.
  */
 - (void)runQuery:(KIOQuery *)keenQuery completionHandler:(AnalysisCompletionBlock)completionHandler
-DEPRECATED_MSG_ATTRIBUTE("use runAsyncQuery:withCompletion: instead.");
+DEPRECATED_MSG_ATTRIBUTE("use runAsyncQuery:completionHandler: instead.");
 
 /**
  Runs a synchronous multi-analysis query.
@@ -362,7 +362,7 @@ DEPRECATED_MSG_ATTRIBUTE("use runAsyncQuery:withCompletion: instead.");
  */
 - (void)runMultiAnalysisWithQueries:(NSArray *)keenQueries
                   completionHandler:(void (^)(NSData *data, NSURLResponse *response, NSError *error))completionHandler
-                  DEPRECATED_MSG_ATTRIBUTE("use runAsyncMultiAnalysisWithQueries:withCompletion: instead.");
+                  DEPRECATED_MSG_ATTRIBUTE("use runAsyncMultiAnalysisWithQueries:completionHandler: instead.");
 
 /**
  Call this to indiscriminately delete all queries.

--- a/KeenClient/KeenClient.h
+++ b/KeenClient/KeenClient.h
@@ -16,6 +16,9 @@
 // defines a type for the block we'll use with our global properties
 typedef NSDictionary* (^KeenGlobalPropertiesBlock)(NSString *eventCollection);
 
+// Block type for analysis/query completion
+typedef void (^AnalysisCompletionBlock)(NSData *, NSURLResponse *, NSError *);
+
 /**
  KeenClient has class methods to return managed instances of itself and instance methods
  to collect new events and upload them through the Keen IO API.
@@ -188,7 +191,7 @@ typedef NSDictionary* (^KeenGlobalPropertiesBlock)(NSString *eventCollection);
 /**
  Call this to indiscriminately delete all events queued for sending.
  */
-+ (void)clearAllEvents DEPRECATED_MSG_ATTRIBUTE("Class method clearAllEvents is deprecated. Use instance method instead.");
++ (void)clearAllEvents DEPRECATED_MSG_ATTRIBUTE("use instance method instead.");
 - (void)clearAllEvents;
 
 
@@ -197,7 +200,7 @@ typedef NSDictionary* (^KeenGlobalPropertiesBlock)(NSString *eventCollection);
 
  @return An instance of KIOEventStore.
  */
-+ (KIODBStore*)getDBStore DEPRECATED_MSG_ATTRIBUTE("Class method getDBStore is deprecated. User instance method instead.");
++ (KIODBStore*)getDBStore DEPRECATED_MSG_ATTRIBUTE("use instance method instead.");
 - (KIODBStore*)getDBStore;
 
 /**
@@ -302,7 +305,18 @@ typedef NSDictionary* (^KeenGlobalPropertiesBlock)(NSString *eventCollection);
  @param keenQuery The KIOQuery object containing the information about the query.
  @param block The block to be executed once querying is finished. It receives an NSData object containing the query results, and an NSURLResponse and NSError objects.
  */
-- (void)runAsyncQuery:(KIOQuery *)keenQuery block:(void (^)(NSData *, NSURLResponse *, NSError *))block;
+- (void)runAsyncQuery:(KIOQuery *)keenQuery block:(AnalysisCompletionBlock)block
+DEPRECATED_MSG_ATTRIBUTE("it has been renamed to runQuery:withCompletion:");
+
+/**
+ Runs an asynchronous query.
+
+ See detailed documentation here: https://keen.io/docs/api/#analyses
+
+ @param keenQuery The KIOQuery object containing the information about the query.
+ @param completion The block to be executed once querying is finished. It receives an NSData object containing the query results, and an NSURLResponse and NSError objects.
+ */
+- (void)runAsyncQuery:(KIOQuery *)keenQuery withCompletion:(AnalysisCompletionBlock)completion;
 
 /**
  Runs an asynchronous multi-analysis query.
@@ -312,7 +326,18 @@ typedef NSDictionary* (^KeenGlobalPropertiesBlock)(NSString *eventCollection);
  @param keenQueries The NSArray object containing multiple KIOQuery objects. They must all contain the same value for the event_collection property.
  @param block The block to be executed once querying is finished. It receives an NSData object containing the query results, and an NSURLResponse and NSError objects.
  */
-- (void)runAsyncMultiAnalysisWithQueries:(NSArray *)keenQueries block:(void (^)(NSData *, NSURLResponse *, NSError *))block;
+- (void)runAsyncMultiAnalysisWithQueries:(NSArray *)keenQueries block:(AnalysisCompletionBlock)block
+DEPRECATED_MSG_ATTRIBUTE("it has been renamed to runAsyncMultiAnalysisWithQueries:withCompletion:");
+
+/**
+ Runs an asynchronous multi-analysis query.
+
+ See detailed documentation here: https://keen.io/docs/api/#multi-analysis
+
+ @param keenQueries The NSArray object containing multiple KIOQuery objects. They must all contain the same value for the event_collection property.
+ @param completion The block to be executed once querying is finished. It receives an NSData object containing the query results, and an NSURLResponse and NSError objects.
+ */
+- (void)runAsyncMultiAnalysisWithQueries:(NSArray *)keenQueries withCompletion:(AnalysisCompletionBlock)completion;
 
 /**
  Runs a synchronous query.
@@ -323,7 +348,8 @@ typedef NSDictionary* (^KeenGlobalPropertiesBlock)(NSString *eventCollection);
  @param returningResponse The NSURLResponse for the query.
  @param error The NSError (if any) for the query.
  */
-- (void)runQuery:(KIOQuery *)keenQuery completionHandler:(void (^)(NSData *data, NSURLResponse *response, NSError *error))completionHandler;
+- (void)runQuery:(KIOQuery *)keenQuery completionHandler:(AnalysisCompletionBlock)completionHandler
+DEPRECATED_MSG_ATTRIBUTE("use runAsyncQuery:withCompletion: instead.");
 
 /**
  Runs a synchronous multi-analysis query.
@@ -334,12 +360,14 @@ typedef NSDictionary* (^KeenGlobalPropertiesBlock)(NSString *eventCollection);
  @param returningResponse The NSURLResponse for the query.
  @param error The NSError (if any) for the query.
  */
-- (void)runMultiAnalysisWithQueries:(NSArray *)keenQueries completionHandler:(void (^)(NSData *data, NSURLResponse *response, NSError *error))completionHandler;
+- (void)runMultiAnalysisWithQueries:(NSArray *)keenQueries
+                  completionHandler:(void (^)(NSData *data, NSURLResponse *response, NSError *error))completionHandler
+                  DEPRECATED_MSG_ATTRIBUTE("use runAsyncMultiAnalysisWithQueries:withCompletion: instead.");
 
 /**
  Call this to indiscriminately delete all queries.
  */
-+ (void)clearAllQueries DEPRECATED_MSG_ATTRIBUTE("Class method clearAllQueries is deprecated. Use instance method instead.");
++ (void)clearAllQueries DEPRECATED_MSG_ATTRIBUTE("use instance method instead.");
 - (void)clearAllQueries;
 
 

--- a/KeenClient/KeenClient.h
+++ b/KeenClient/KeenClient.h
@@ -306,7 +306,7 @@ typedef void (^AnalysisCompletionBlock)(NSData *, NSURLResponse *, NSError *);
  @param block The block to be executed once querying is finished. It receives an NSData object containing the query results, and an NSURLResponse and NSError objects.
  */
 - (void)runAsyncQuery:(KIOQuery *)keenQuery block:(AnalysisCompletionBlock)block
-DEPRECATED_MSG_ATTRIBUTE("it has been renamed to runAsyncQuery:completionHandler:");
+    DEPRECATED_MSG_ATTRIBUTE("it has been renamed to runAsyncQuery:completionHandler:");
 
 /**
  Runs an asynchronous query.
@@ -327,7 +327,7 @@ DEPRECATED_MSG_ATTRIBUTE("it has been renamed to runAsyncQuery:completionHandler
  @param block The block to be executed once querying is finished. It receives an NSData object containing the query results, and an NSURLResponse and NSError objects.
  */
 - (void)runAsyncMultiAnalysisWithQueries:(NSArray *)keenQueries block:(AnalysisCompletionBlock)block
-DEPRECATED_MSG_ATTRIBUTE("it has been renamed to runAsyncMultiAnalysisWithQueries:completionHandler:");
+    DEPRECATED_MSG_ATTRIBUTE("it has been renamed to runAsyncMultiAnalysisWithQueries:completionHandler:");
 
 /**
  Runs an asynchronous multi-analysis query.
@@ -349,7 +349,7 @@ DEPRECATED_MSG_ATTRIBUTE("it has been renamed to runAsyncMultiAnalysisWithQuerie
  @param error The NSError (if any) for the query.
  */
 - (void)runQuery:(KIOQuery *)keenQuery completionHandler:(AnalysisCompletionBlock)completionHandler
-DEPRECATED_MSG_ATTRIBUTE("use runAsyncQuery:completionHandler: instead.");
+    DEPRECATED_MSG_ATTRIBUTE("use runAsyncQuery:completionHandler: instead.");
 
 /**
  Runs a synchronous multi-analysis query.
@@ -360,9 +360,8 @@ DEPRECATED_MSG_ATTRIBUTE("use runAsyncQuery:completionHandler: instead.");
  @param returningResponse The NSURLResponse for the query.
  @param error The NSError (if any) for the query.
  */
-- (void)runMultiAnalysisWithQueries:(NSArray *)keenQueries
-                  completionHandler:(void (^)(NSData *data, NSURLResponse *response, NSError *error))completionHandler
-                  DEPRECATED_MSG_ATTRIBUTE("use runAsyncMultiAnalysisWithQueries:completionHandler: instead.");
+- (void)runMultiAnalysisWithQueries:(NSArray *)keenQueries completionHandler:(AnalysisCompletionBlock)completionHandler
+    DEPRECATED_MSG_ATTRIBUTE("use runAsyncMultiAnalysisWithQueries:completionHandler: instead.");
 
 /**
  Call this to indiscriminately delete all queries.

--- a/KeenClient/KeenClient.m
+++ b/KeenClient/KeenClient.m
@@ -641,10 +641,10 @@ static BOOL geoLocationRequestEnabled = YES;
 # pragma mark Async methods
 
 - (void)runAsyncQuery:(KIOQuery *)keenQuery block:(AnalysisCompletionBlock)block {
-    [self runAsyncQuery:keenQuery withCompletion:block];
+    [self runAsyncQuery:keenQuery completionHandler:block];
 }
 
-- (void)runAsyncQuery:(KIOQuery *)keenQuery withCompletion:(AnalysisCompletionBlock)completion {
+- (void)runAsyncQuery:(KIOQuery *)keenQuery completionHandler:(AnalysisCompletionBlock)completionHandler {
     dispatch_async(self.queryQueue, ^{
         [self.network runQuery:keenQuery
                  withProjectID:self.projectID
@@ -653,10 +653,10 @@ static BOOL geoLocationRequestEnabled = YES;
             // we're done querying, call the main queue and execute the block
             dispatch_async(dispatch_get_main_queue(), ^{
                 // run the user-specific block (if there is one)
-                if (completion) {
+                if (completionHandler) {
                     KCLogVerbose(@"Running user-specified block.");
                     @try {
-                        completion(data, response, error);
+                        completionHandler(data, response, error);
                     } @finally {
                         // do nothing
                     }
@@ -667,10 +667,10 @@ static BOOL geoLocationRequestEnabled = YES;
 }
 
 - (void)runAsyncMultiAnalysisWithQueries:(NSArray *)keenQueries block:(AnalysisCompletionBlock)block {
-    [self runAsyncMultiAnalysisWithQueries:keenQueries withCompletion:block];
+    [self runAsyncMultiAnalysisWithQueries:keenQueries completionHandler:block];
 }
 
-- (void)runAsyncMultiAnalysisWithQueries:(NSArray *)keenQueries withCompletion:(AnalysisCompletionBlock)completion {
+- (void)runAsyncMultiAnalysisWithQueries:(NSArray *)keenQueries completionHandler:(AnalysisCompletionBlock)completionHandler {
     dispatch_async(self.queryQueue, ^{
         [self.network runMultiAnalysisWithQueries:keenQueries
                                     withProjectID:self.projectID
@@ -679,10 +679,10 @@ static BOOL geoLocationRequestEnabled = YES;
             // we're done querying, call the main queue and execute the block
             dispatch_async(dispatch_get_main_queue(), ^{
                 // run the user-specific block (if there is one)
-                if (completion) {
+                if (completionHandler) {
                     KCLogVerbose(@"Running user-specified block.");
                     @try {
-                        completion(data, response, error);
+                        completionHandler(data, response, error);
                     } @finally {
                         // do nothing
                     }

--- a/KeenClient/KeenClient.m
+++ b/KeenClient/KeenClient.m
@@ -640,16 +640,23 @@ static BOOL geoLocationRequestEnabled = YES;
 
 # pragma mark Async methods
 
-- (void)runAsyncQuery:(KIOQuery *)keenQuery block:(void (^)(NSData *, NSURLResponse *, NSError *))block {
+- (void)runAsyncQuery:(KIOQuery *)keenQuery block:(AnalysisCompletionBlock)block {
+    [self runAsyncQuery:keenQuery withCompletion:block];
+}
+
+- (void)runAsyncQuery:(KIOQuery *)keenQuery withCompletion:(AnalysisCompletionBlock)completion {
     dispatch_async(self.queryQueue, ^{
-        [self runQuery:keenQuery completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
+        [self.network runQuery:keenQuery
+                 withProjectID:self.projectID
+                   withReadKey:self.readKey
+             completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
             // we're done querying, call the main queue and execute the block
             dispatch_async(dispatch_get_main_queue(), ^{
                 // run the user-specific block (if there is one)
-                if (block) {
+                if (completion) {
                     KCLogVerbose(@"Running user-specified block.");
                     @try {
-                        block(data, response, error);
+                        completion(data, response, error);
                     } @finally {
                         // do nothing
                     }
@@ -659,17 +666,23 @@ static BOOL geoLocationRequestEnabled = YES;
     });
 }
 
-- (void)runAsyncMultiAnalysisWithQueries:(NSArray *)keenQueries block:(void (^)(NSData *, NSURLResponse *, NSError *))block {
+- (void)runAsyncMultiAnalysisWithQueries:(NSArray *)keenQueries block:(AnalysisCompletionBlock)block {
+    [self runAsyncMultiAnalysisWithQueries:keenQueries withCompletion:block];
+}
+
+- (void)runAsyncMultiAnalysisWithQueries:(NSArray *)keenQueries withCompletion:(AnalysisCompletionBlock)completion {
     dispatch_async(self.queryQueue, ^{
-        [self runMultiAnalysisWithQueries:keenQueries
-                        completionHandler:^(NSData* data, NSURLResponse* response, NSError* error) {
+        [self.network runMultiAnalysisWithQueries:keenQueries
+                                    withProjectID:self.projectID
+                                      withReadKey:self.readKey
+                                completionHandler:^(NSData* data, NSURLResponse* response, NSError* error) {
             // we're done querying, call the main queue and execute the block
             dispatch_async(dispatch_get_main_queue(), ^{
                 // run the user-specific block (if there is one)
-                if (block) {
+                if (completion) {
                     KCLogVerbose(@"Running user-specified block.");
                     @try {
-                        block(data, response, error);
+                        completion(data, response, error);
                     } @finally {
                         // do nothing
                     }
@@ -679,14 +692,15 @@ static BOOL geoLocationRequestEnabled = YES;
     });
 }
 
-- (void)runQuery:(KIOQuery *)keenQuery completionHandler:(void (^)(NSData *data, NSURLResponse *response, NSError *error))completionHandler {
+- (void)runQuery:(KIOQuery *)keenQuery completionHandler:(AnalysisCompletionBlock)completionHandler {
     [self.network runQuery:keenQuery
              withProjectID:self.projectID
                withReadKey:self.readKey
          completionHandler:completionHandler];
 }
 
-- (void)runMultiAnalysisWithQueries:(NSArray *)keenQueries completionHandler:(void (^)(NSData *data, NSURLResponse *response, NSError *error))completionHandler {
+- (void)runMultiAnalysisWithQueries:(NSArray *)keenQueries
+                  completionHandler:(AnalysisCompletionBlock)completionHandler {
     [self.network runMultiAnalysisWithQueries:keenQueries
                                 withProjectID:self.projectID
                                   withReadKey:self.readKey

--- a/KeenClientExample/KeenClientExample/ThirdViewController.m
+++ b/KeenClientExample/KeenClientExample/ThirdViewController.m
@@ -49,47 +49,47 @@
                                             JSONObjectWithData:responseData
                                             options:kNilOptions
                                             error:nil];
-        
+
         NSLog(@"response: %@", responseDictionary);
         NSLog(@"error: %@", [error localizedDescription]);
-        
+
         NSNumber *result = [responseDictionary objectForKey:@"result"];
-        
+
         NSLog(@"result: %@", result);
-        
+
         // Get result value when querying with group_by property
         //NSNumber *resultValue = [[responseDictionary objectForKey:@"result"][0] objectForKey:@"result"];
         //NSLog(@"resultValue: %@", resultValue);
-        
+
         if(error || [responseDictionary objectForKey:@"error_code"]) {
             self.resultTextView.text = [NSString stringWithFormat:@"Failure! 😞 \n\n error: %@\n\n response: %@", [error localizedDescription] ,[responseDictionary description]];
         } else {
             self.resultTextView.text = [NSString stringWithFormat:@"Success! 😄 \n\n response: %@", [responseDictionary description]];
         }
     };
-    
+
     // Async querying
     KIOQuery *countQuery = [[KIOQuery alloc] initWithQuery:@"count" andPropertiesDictionary:@{@"event_collection": @"collection", @"timeframe": @"this_7_days"}];
-    
-    [[KeenClient sharedClient] runAsyncQuery:countQuery block:countQueryCompleted];
-    
+
+    [[KeenClient sharedClient] runAsyncQuery:countQuery withCompletion:countQueryCompleted];
+
     // Multi-analysis querying example
     /*
     KIOQuery *countUniqueQuery = [[KIOQuery alloc] initWithQuery:@"count_unique" andPropertiesDictionary:@{@"event_collection": @"collection", @"target_property": @"key", @"timeframe": @"this_7_days"}];
-    
+
     [countQuery setQueryName:@"count_query"];
     [countUniqueQuery setQueryName:@"count_unique_query"];
-    
+
     [[KeenClient sharedClient] runAsyncMultiAnalysisWithQueries:@[countQuery, countUniqueQuery] block:countQueryCompleted];
      */
-    
+
     // Funnel example
     /*
     KIOQuery *funnelQuery = [[KIOQuery alloc] initWithQuery:@"funnel" andPropertiesDictionary:@{@"timeframe": @"this_7_days", @"steps": @[@{@"event_collection": @"user_signed_up",
             @"actor_property": @"user.id"},
           @{@"event_collection": @"user_completed_profile",
             @"actor_property": @"user.id"}]}];
-    
+
     [[KeenClient sharedClient] runAsyncQuery:funnelQuery block:countQueryCompleted];
      */
 }

--- a/KeenClientExample/KeenClientExample/ThirdViewController.m
+++ b/KeenClientExample/KeenClientExample/ThirdViewController.m
@@ -71,7 +71,7 @@
     // Async querying
     KIOQuery *countQuery = [[KIOQuery alloc] initWithQuery:@"count" andPropertiesDictionary:@{@"event_collection": @"collection", @"timeframe": @"this_7_days"}];
 
-    [[KeenClient sharedClient] runAsyncQuery:countQuery withCompletion:countQueryCompleted];
+    [[KeenClient sharedClient] runAsyncQuery:countQuery completionHandler:countQueryCompleted];
 
     // Multi-analysis querying example
     /*

--- a/KeenClientTests/KIODBStoreTests.m
+++ b/KeenClientTests/KIODBStoreTests.m
@@ -31,9 +31,9 @@
     } else {
         NSLog(@"Failed to remove database file.");
     }
-    
+
     projectID = @"pid";
-    
+
     [super setUp];
 }
 
@@ -62,7 +62,7 @@
 - (void)testClosedDB {
     KIODBStore *store = [[KIODBStore alloc] init];
     [store closeDB];
-    
+
     // Verify that these methods all behave with a closed database.
     XCTAssertFalse([store hasPendingEventsWithProjectID:projectID], @"no pending if closed");
     [store resetPendingEventsWithProjectID:projectID]; // This shouldn't crash. :P
@@ -183,9 +183,9 @@
 - (void)testQueryAdd {
     KIODBStore *store = [[KIODBStore alloc] init];
     KIOQuery *query = [[KIOQuery alloc] initWithQuery:@"count" andPropertiesDictionary:@{@"event_collection": @"collection"}];
-    
+
     [store addQuery:[query convertQueryToData] queryType:query.queryType collection:[query.propertiesDictionary objectForKey:@"event_collection"] projectID:projectID];
-    
+
     XCTAssertTrue([store getTotalQueryCountWithProjectID:projectID] == 1, @"1 total event after add");
 }
 
@@ -193,119 +193,119 @@
     KIODBStore *store = [[KIODBStore alloc] init];
     KIOQuery *query = [[KIOQuery alloc] initWithQuery:@"count" andPropertiesDictionary:@{@"event_collection": @"collection"}];
     KIOQuery *query2 = [[KIOQuery alloc] initWithQuery:@"count_unique" andPropertiesDictionary:@{@"event_collection": @"collection2"}];
-    
+
     [store addQuery:[query convertQueryToData] queryType:query.queryType collection:[query.propertiesDictionary objectForKey:@"event_collection"] projectID:projectID];
     [store addQuery:[query2 convertQueryToData] queryType:query2.queryType collection:[query2.propertiesDictionary objectForKey:@"event_collection"] projectID:projectID];
-    
+
     XCTAssertTrue([store getTotalQueryCountWithProjectID:projectID] == 2, @"2 total event after add");
-    
+
     NSMutableDictionary *returnedQuery = [store getQuery:[query convertQueryToData] queryType:query.queryType collection:[query.propertiesDictionary objectForKey:@"event_collection"] projectID:projectID];
-    
+
     XCTAssertNotNil(returnedQuery, @"returned query is not nil");
     XCTAssertEqualObjects([query.propertiesDictionary objectForKey:@"event_collection"], [returnedQuery objectForKey:@"event_collection"], @"event collection is the same");
     XCTAssertEqualObjects([query convertQueryToData], [returnedQuery objectForKey:@"queryData"], @"query data is the same");
     XCTAssertEqualObjects(query.queryType, [returnedQuery objectForKey:@"queryType"], @"query type is the same");
-    XCTAssertEqual([returnedQuery objectForKey:@"attempts"], [NSNumber numberWithInt:0], @"attempts is 0");
-    
+    XCTAssertEqual([[returnedQuery objectForKey:@"attempts"] intValue], 0, @"attempts is 0");
+
     NSMutableDictionary *returnedQuery2 = [store getQuery:[query2 convertQueryToData] queryType:query2.queryType collection:[query2.propertiesDictionary objectForKey:@"event_collection"] projectID:projectID];
-    
+
     XCTAssertNotNil(returnedQuery2, @"returned query is not nil");
     XCTAssertEqualObjects([query2.propertiesDictionary objectForKey:@"event_collection"], [returnedQuery2 objectForKey:@"event_collection"], @"event collection is the same");
     XCTAssertEqualObjects([query2 convertQueryToData], [returnedQuery2 objectForKey:@"queryData"], @"query data is the same");
-    XCTAssertEqual([returnedQuery2 objectForKey:@"attempts"], [NSNumber numberWithInt:0], @"attempts is 0");
+    XCTAssertEqual([[returnedQuery2 objectForKey:@"attempts"] intValue], 0, @"attempts is 0");
 }
 
 - (void) testQueryUpdate {
     KIODBStore *store = [[KIODBStore alloc] init];
     KIOQuery *query = [[KIOQuery alloc] initWithQuery:@"count" andPropertiesDictionary:@{@"event_collection": @"collection"}];
-    
+
     // first add and retrieve query, make sure attempts is 0
     [store addQuery:[query convertQueryToData] queryType:query.queryType collection:[query.propertiesDictionary objectForKey:@"event_collection"] projectID:projectID];
-    
+
     NSMutableDictionary *returnedQuery = [store getQuery:[query convertQueryToData] queryType:query.queryType collection:[query.propertiesDictionary objectForKey:@"event_collection"] projectID:projectID];
-    
-    XCTAssertEqual([returnedQuery objectForKey:@"attempts"], [NSNumber numberWithInt:0], @"attempts is 0");
-    
+
+    XCTAssertEqual([[returnedQuery objectForKey:@"attempts"] intValue], 0, @"attempts is 0");
+
     // update query attempts
     BOOL wasQueryUpdated = [store incrementQueryAttempts:[returnedQuery objectForKey:@"queryID"]];
-    
+
     XCTAssertTrue(wasQueryUpdated);
-    
+
     // grab updated query and check attempt number
     NSMutableDictionary *returnUpdateQuery = [store getQuery:[query convertQueryToData] queryType:query.queryType collection:[query.propertiesDictionary objectForKey:@"event_collection"] projectID:projectID];
-    
+
     XCTAssertNotNil(returnUpdateQuery, @"returned query is not nil");
     XCTAssertEqualObjects([query.propertiesDictionary objectForKey:@"event_collection"], [returnUpdateQuery objectForKey:@"event_collection"], @"event collection is the same");
     XCTAssertEqualObjects([query convertQueryToData], [returnUpdateQuery objectForKey:@"queryData"], @"query data is the same");
-    XCTAssertEqual([returnUpdateQuery objectForKey:@"attempts"], [NSNumber numberWithInt:1], @"attempts is 1");
+    XCTAssertEqual([[returnUpdateQuery objectForKey:@"attempts"] intValue], 1, @"attempts is 1");
 }
 
 - (void) testQueryDeleteAll {
     KIODBStore *store = [[KIODBStore alloc] init];
     KIOQuery *query = [[KIOQuery alloc] initWithQuery:@"count" andPropertiesDictionary:@{@"event_collection": @"collection"}];
-    
+
     [store addQuery:[query convertQueryToData] queryType:query.queryType collection:[query.propertiesDictionary objectForKey:@"event_collection"] projectID:projectID];
-    
+
     XCTAssertTrue([store getTotalQueryCountWithProjectID:projectID] == 1, @"1 total query after add");
-    
+
     [store deleteAllQueries];
-    
+
     XCTAssertTrue([store getTotalQueryCountWithProjectID:projectID] == 0, @"0 total query after deleteAllQueries");
 }
 
 - (void) testHasQueryWithMaxAttempts {
     KIODBStore *store = [[KIODBStore alloc] init];
     KIOQuery *query = [[KIOQuery alloc] initWithQuery:@"count" andPropertiesDictionary:@{@"event_collection": @"collection"}];
-    
+
     [store addQuery:[query convertQueryToData] queryType:query.queryType collection:[query.propertiesDictionary objectForKey:@"event_collection"] projectID:projectID];
-    
+
     XCTAssertTrue([store getTotalQueryCountWithProjectID:projectID] == 1, @"1 total query after add");
-    
+
     // test that query succeds with maxAttempts set to 0
     int maxAttempts = 0;
-    
+
     BOOL hasQueryWithMaxAttempts = [store hasQueryWithMaxAttempts:[query convertQueryToData] queryType:query.queryType collection:[query.propertiesDictionary objectForKey:@"event_collection"] projectID:projectID maxAttempts:maxAttempts queryTTL:1];
-    
+
     XCTAssertTrue(hasQueryWithMaxAttempts, @"query found with attempts equal to or over 0");
-    
+
     // test that query fails with maxAttempts set to 1
     maxAttempts = 1;
-    
+
     hasQueryWithMaxAttempts = [store hasQueryWithMaxAttempts:[query convertQueryToData] queryType:query.queryType collection:[query.propertiesDictionary objectForKey:@"event_collection"] projectID:projectID maxAttempts:maxAttempts queryTTL:1];
-    
+
     XCTAssertFalse(hasQueryWithMaxAttempts, @"query not found with attempts equal to or over 1");
-    
+
     // test that query succeds after query attempts value is incremented
     NSMutableDictionary *returnedQuery = [store getQuery:[query convertQueryToData] queryType:query.queryType collection:[query.propertiesDictionary objectForKey:@"event_collection"] projectID:projectID];
-    
+
     [store incrementQueryAttempts:[returnedQuery objectForKey:@"queryID"]];
-    
+
     hasQueryWithMaxAttempts = [store hasQueryWithMaxAttempts:[query convertQueryToData] queryType:query.queryType collection:[query.propertiesDictionary objectForKey:@"event_collection"] projectID:projectID maxAttempts:maxAttempts queryTTL:1];
-    
+
     XCTAssertTrue(hasQueryWithMaxAttempts, @"query found with attempts equal to or over 1");
 }
 
 - (void)testDeleteQueriesOlderThanXSeconds {
     KIODBStore *store = [[KIODBStore alloc] init];
     KIOQuery *query = [[KIOQuery alloc] initWithQuery:@"count" andPropertiesDictionary:@{@"event_collection": @"collection"}];
-    
+
     [store addQuery:[query convertQueryToData] queryType:query.queryType collection:[query.propertiesDictionary objectForKey:@"event_collection"] projectID:projectID];
-    
+
     int totalQueries = [store getTotalQueryCountWithProjectID:projectID];
     XCTAssertTrue(totalQueries == 1, @"1 total query after add");
-    
+
     // wait for 2 seconds
     [NSThread sleepForTimeInterval:2.0];
 
     // try to delete queries older than 10 seconds
     [store deleteQueriesOlderThan:[NSNumber numberWithInt:10]];
-    
+
     totalQueries = [store getTotalQueryCountWithProjectID:projectID];
     XCTAssertTrue(totalQueries == 1, @"1 total query after trying to delete queries older than 10 seconds");
-    
+
     // try to delete queries older than 1 second
     [store deleteQueriesOlderThan:[NSNumber numberWithInt:1]];
-    
+
     totalQueries = [store getTotalQueryCountWithProjectID:projectID];
     XCTAssertTrue(totalQueries == 0, @"0 total query after trying to delete queries older than 1 seconds");
 }
@@ -313,28 +313,28 @@
 - (void)testRecoverFromCorruptDb {
     // Copy a canned corrupt db to the db path
     [self setUpCorruptDb];
-    
+
     KIODBStore *store = [[KIODBStore alloc] init];
     XCTAssertNotNil(store, @"init is not null");
     NSString *dbPath = [self databaseFile];
     NSFileManager *fileManager = [NSFileManager defaultManager];
     XCTAssertTrue([fileManager fileExistsAtPath:dbPath], @"Database file exists.");
-    
+
     NSString* event = @"{ \"event\": \"something\" }";
-    
+
     XCTAssertTrue([store getTotalEventCountWithProjectID:projectID] == 0, @"0 pending events after init");
     XCTAssertTrue([store addEvent:[event dataUsingEncoding:NSUTF8StringEncoding] collection:@"collection" projectID:projectID]);
     XCTAssertTrue([store getTotalEventCountWithProjectID:projectID] == 1, @"1 pending events after add");
 
     NSMutableDictionary* events = [store getEventsWithMaxAttempts:3 andProjectID:projectID];
-    
+
     XCTAssertEqual(events.count, 1, @"Should only be one event in the store");
     for (NSString *coll in events) {
         for (NSNumber *eid in [events objectForKey:coll]) {
             [store deleteEvent:eid];
         }
     }
-    
+
     XCTAssertTrue([store getPendingEventCountWithProjectID:projectID] == 0, @"0 pending events after init");
 }
 

--- a/KeenClientTests/KeenClientTests.m
+++ b/KeenClientTests/KeenClientTests.m
@@ -1629,7 +1629,7 @@ NSString* kDefaultReadKey = @"rk";
 
     KIOQuery *query = [[KIOQuery alloc] initWithQuery:@"count" andPropertiesDictionary:@{}];
 
-    [mock runAsyncQuery:query withCompletion:^(NSData *queryResponseData, NSURLResponse *response, NSError *error) {
+    [mock runAsyncQuery:query completionHandler:^(NSData *queryResponseData, NSURLResponse *response, NSError *error) {
         KCLogInfo(@"error: %@", error);
         KCLogInfo(@"response: %@", response);
 
@@ -1656,7 +1656,7 @@ NSString* kDefaultReadKey = @"rk";
 
     KIOQuery *query = [[KIOQuery alloc] initWithQuery:@"count" andPropertiesDictionary:@{@"event_collection": @"event_collection"}];
 
-    [mock runAsyncQuery:query withCompletion:^(NSData *queryResponseData, NSURLResponse *response, NSError *error) {
+    [mock runAsyncQuery:query completionHandler:^(NSData *queryResponseData, NSURLResponse *response, NSError *error) {
         KCLogInfo(@"error: %@", error);
         KCLogInfo(@"response: %@", response);
 
@@ -1684,7 +1684,7 @@ NSString* kDefaultReadKey = @"rk";
     KIOQuery *query = [[KIOQuery alloc] initWithQuery:@"count" andPropertiesDictionary:@{@"event_collection": @"event_collection",
                                                                                          @"group_by": @"key"}];
 
-    [mock runAsyncQuery:query withCompletion:^(NSData *queryResponseData, NSURLResponse *response, NSError *error) {
+    [mock runAsyncQuery:query completionHandler:^(NSData *queryResponseData, NSURLResponse *response, NSError *error) {
         KCLogInfo(@"error: %@", error);
         KCLogInfo(@"response: %@", response);
 
@@ -1715,7 +1715,7 @@ NSString* kDefaultReadKey = @"rk";
                                                        @"interval": @"daily",
                                                        @"timeframe": @"last_1_days"}];
 
-    [mock runAsyncQuery:query withCompletion:^(NSData *queryResponseData, NSURLResponse *response, NSError *error) {
+    [mock runAsyncQuery:query completionHandler:^(NSData *queryResponseData, NSURLResponse *response, NSError *error) {
         KCLogInfo(@"error: %@", error);
         KCLogInfo(@"response: %@", response);
 
@@ -1742,7 +1742,7 @@ NSString* kDefaultReadKey = @"rk";
 
     KIOQuery *query = [[KIOQuery alloc] initWithQuery:@"count" andPropertiesDictionary:@{@"event_collection": @"event_collection"}];
 
-    [mock runAsyncQuery:query withCompletion:^(NSData *queryResponseData, NSURLResponse *response, NSError *error) {
+    [mock runAsyncQuery:query completionHandler:^(NSData *queryResponseData, NSURLResponse *response, NSError *error) {
         KCLogInfo(@"error: %@", error);
         KCLogInfo(@"response: %@", response);
 
@@ -1769,7 +1769,7 @@ NSString* kDefaultReadKey = @"rk";
 
     KIOQuery *query = [[KIOQuery alloc] initWithQuery:@"count" andPropertiesDictionary:@{@"event_collection": @"event_collection", @"target_property": @"something"}];
 
-    [mock runAsyncQuery:query withCompletion:^(NSData *queryResponseData, NSURLResponse *response, NSError *error) {
+    [mock runAsyncQuery:query completionHandler:^(NSData *queryResponseData, NSURLResponse *response, NSError *error) {
         KCLogInfo(@"error: %@", error);
         KCLogInfo(@"response: %@", response);
 
@@ -1799,7 +1799,7 @@ NSString* kDefaultReadKey = @"rk";
     KIOQuery *averageQuery = [[KIOQuery alloc] initWithQuery:@"count_unique" andPropertiesDictionary:@{@"event_collection": @"event_collection", @"target_property": @"something"}];
 
     [mock runAsyncMultiAnalysisWithQueries:@[countQuery, averageQuery]
-                            withCompletion:^(NSData *queryResponseData, NSURLResponse *response, NSError *error) {
+                         completionHandler:^(NSData *queryResponseData, NSURLResponse *response, NSError *error) {
         KCLogInfo(@"error: %@", error);
         KCLogInfo(@"response: %@", response);
 
@@ -1831,7 +1831,7 @@ NSString* kDefaultReadKey = @"rk";
     KIOQuery *query = [[KIOQuery alloc] initWithQuery:@"funnel" andPropertiesDictionary:@{@"steps": @[@{@"event_collection": @"user_signed_up", @"actor_property": @"user.id"},
                                                                                                       @{@"event_collection": @"user_completed_profile", @"actor_property": @"user.id"}]}];
 
-    [mock runAsyncQuery:query withCompletion:^(NSData *queryResponseData, NSURLResponse *response, NSError *error) {
+    [mock runAsyncQuery:query completionHandler:^(NSData *queryResponseData, NSURLResponse *response, NSError *error) {
         KCLogInfo(@"error: %@", error);
         KCLogInfo(@"response: %@", response);
 
@@ -1989,7 +1989,7 @@ NSString* kDefaultReadKey = @"rk";
     KIOQuery *query = [[KIOQuery alloc] initWithQuery:@"count" andPropertiesDictionary:@{@"event_collection": @"event_collection"}];
 
     XCTestExpectation* responseArrived = [self expectationWithDescription:@"response of async request has arrived"];
-    [client runAsyncQuery:query withCompletion:^(NSData *queryResponseData, NSURLResponse *response, NSError *error) {
+    [client runAsyncQuery:query completionHandler:^(NSData *queryResponseData, NSURLResponse *response, NSError *error) {
         // Check for the sdk version header
         [urlSessionMock verify];
 
@@ -2021,7 +2021,7 @@ NSString* kDefaultReadKey = @"rk";
 
     XCTestExpectation* responseArrived = [self expectationWithDescription:@"response of async request has arrived"];
     [client runAsyncMultiAnalysisWithQueries:@[countQuery, averageQuery]
-                              withCompletion:^(NSData* queryResponseData, NSURLResponse* response, NSError* error) {
+                           completionHandler:^(NSData* queryResponseData, NSURLResponse* response, NSError* error) {
         // Check for the sdk version header
         [urlSessionMock verify];
 

--- a/KeenClientTests/KeenClientTests.m
+++ b/KeenClientTests/KeenClientTests.m
@@ -583,7 +583,7 @@ NSString* kDefaultReadKey = @"rk";
 
 -(void)testUploadWithNoEvents {
     XCTestExpectation* uploadFinishedBlockCalled = [self expectationWithDescription:@"Upload should finish."];
-    
+
     id mock = [self createClientWithResponseData:nil andStatusCode:HTTPCode200OK];
 
     [mock uploadWithFinishedBlock:^{
@@ -1492,7 +1492,7 @@ NSString* kDefaultReadKey = @"rk";
     XCTestExpectation* uploadFinishedBlockCalled1 = [self expectationWithDescription:@"Upload 1 should run to completion."];
     XCTestExpectation* uploadFinishedBlockCalled2 = [self expectationWithDescription:@"Upload 2 should run to completion."];
     XCTestExpectation* uploadFinishedBlockCalled3 = [self expectationWithDescription:@"Upload 3 should run to completion."];
-    
+
     KeenClient *client = [KeenClient sharedClientWithProjectID:kDefaultProjectID andWriteKey:kDefaultWriteKey andReadKey:kDefaultReadKey];
     client.isRunningTests = YES;
 
@@ -1505,7 +1505,7 @@ NSString* kDefaultReadKey = @"rk";
     [client uploadWithFinishedBlock:^ {
         [uploadFinishedBlockCalled3 fulfill];
     }];
-    
+
     [self waitForExpectationsWithTimeout:_asyncTimeInterval handler:nil];
 }
 
@@ -1526,7 +1526,7 @@ NSString* kDefaultReadKey = @"rk";
     [client uploadWithFinishedBlock:^ {
         [uploadFinishedBlockCalled3 fulfill];
     }];
-    
+
     [self waitForExpectationsWithTimeout:_asyncTimeInterval handler:nil];
 }
 
@@ -1629,7 +1629,7 @@ NSString* kDefaultReadKey = @"rk";
 
     KIOQuery *query = [[KIOQuery alloc] initWithQuery:@"count" andPropertiesDictionary:@{}];
 
-    [mock runQuery:query completionHandler:^(NSData *queryResponseData, NSURLResponse *response, NSError *error) {
+    [mock runAsyncQuery:query withCompletion:^(NSData *queryResponseData, NSURLResponse *response, NSError *error) {
         KCLogInfo(@"error: %@", error);
         KCLogInfo(@"response: %@", response);
 
@@ -1656,7 +1656,7 @@ NSString* kDefaultReadKey = @"rk";
 
     KIOQuery *query = [[KIOQuery alloc] initWithQuery:@"count" andPropertiesDictionary:@{@"event_collection": @"event_collection"}];
 
-    [mock runQuery:query completionHandler:^(NSData *queryResponseData, NSURLResponse *response, NSError *error) {
+    [mock runAsyncQuery:query withCompletion:^(NSData *queryResponseData, NSURLResponse *response, NSError *error) {
         KCLogInfo(@"error: %@", error);
         KCLogInfo(@"response: %@", response);
 
@@ -1684,7 +1684,7 @@ NSString* kDefaultReadKey = @"rk";
     KIOQuery *query = [[KIOQuery alloc] initWithQuery:@"count" andPropertiesDictionary:@{@"event_collection": @"event_collection",
                                                                                          @"group_by": @"key"}];
 
-    [mock runQuery:query completionHandler:^(NSData *queryResponseData, NSURLResponse *response, NSError *error) {
+    [mock runAsyncQuery:query withCompletion:^(NSData *queryResponseData, NSURLResponse *response, NSError *error) {
         KCLogInfo(@"error: %@", error);
         KCLogInfo(@"response: %@", response);
 
@@ -1715,7 +1715,7 @@ NSString* kDefaultReadKey = @"rk";
                                                        @"interval": @"daily",
                                                        @"timeframe": @"last_1_days"}];
 
-    [mock runQuery:query completionHandler:^(NSData *queryResponseData, NSURLResponse *response, NSError *error) {
+    [mock runAsyncQuery:query withCompletion:^(NSData *queryResponseData, NSURLResponse *response, NSError *error) {
         KCLogInfo(@"error: %@", error);
         KCLogInfo(@"response: %@", response);
 
@@ -1742,7 +1742,7 @@ NSString* kDefaultReadKey = @"rk";
 
     KIOQuery *query = [[KIOQuery alloc] initWithQuery:@"count" andPropertiesDictionary:@{@"event_collection": @"event_collection"}];
 
-    [mock runQuery:query completionHandler:^(NSData *queryResponseData, NSURLResponse *response, NSError *error) {
+    [mock runAsyncQuery:query withCompletion:^(NSData *queryResponseData, NSURLResponse *response, NSError *error) {
         KCLogInfo(@"error: %@", error);
         KCLogInfo(@"response: %@", response);
 
@@ -1769,7 +1769,7 @@ NSString* kDefaultReadKey = @"rk";
 
     KIOQuery *query = [[KIOQuery alloc] initWithQuery:@"count" andPropertiesDictionary:@{@"event_collection": @"event_collection", @"target_property": @"something"}];
 
-    [mock runQuery:query completionHandler:^(NSData *queryResponseData, NSURLResponse *response, NSError *error) {
+    [mock runAsyncQuery:query withCompletion:^(NSData *queryResponseData, NSURLResponse *response, NSError *error) {
         KCLogInfo(@"error: %@", error);
         KCLogInfo(@"response: %@", response);
 
@@ -1798,7 +1798,8 @@ NSString* kDefaultReadKey = @"rk";
 
     KIOQuery *averageQuery = [[KIOQuery alloc] initWithQuery:@"count_unique" andPropertiesDictionary:@{@"event_collection": @"event_collection", @"target_property": @"something"}];
 
-    [mock runMultiAnalysisWithQueries:@[countQuery, averageQuery] completionHandler:^(NSData *queryResponseData, NSURLResponse *response, NSError *error) {
+    [mock runAsyncMultiAnalysisWithQueries:@[countQuery, averageQuery]
+                            withCompletion:^(NSData *queryResponseData, NSURLResponse *response, NSError *error) {
         KCLogInfo(@"error: %@", error);
         KCLogInfo(@"response: %@", response);
 
@@ -1830,7 +1831,7 @@ NSString* kDefaultReadKey = @"rk";
     KIOQuery *query = [[KIOQuery alloc] initWithQuery:@"funnel" andPropertiesDictionary:@{@"steps": @[@{@"event_collection": @"user_signed_up", @"actor_property": @"user.id"},
                                                                                                       @{@"event_collection": @"user_completed_profile", @"actor_property": @"user.id"}]}];
 
-    [mock runQuery:query completionHandler:^(NSData *queryResponseData, NSURLResponse *response, NSError *error) {
+    [mock runAsyncQuery:query withCompletion:^(NSData *queryResponseData, NSURLResponse *response, NSError *error) {
         KCLogInfo(@"error: %@", error);
         KCLogInfo(@"response: %@", response);
 
@@ -1988,7 +1989,7 @@ NSString* kDefaultReadKey = @"rk";
     KIOQuery *query = [[KIOQuery alloc] initWithQuery:@"count" andPropertiesDictionary:@{@"event_collection": @"event_collection"}];
 
     XCTestExpectation* responseArrived = [self expectationWithDescription:@"response of async request has arrived"];
-    [client runQuery:query completionHandler:^(NSData *queryResponseData, NSURLResponse *response, NSError *error) {
+    [client runAsyncQuery:query withCompletion:^(NSData *queryResponseData, NSURLResponse *response, NSError *error) {
         // Check for the sdk version header
         [urlSessionMock verify];
 
@@ -2019,8 +2020,8 @@ NSString* kDefaultReadKey = @"rk";
                                      andPropertiesDictionary:@{@"event_collection": @"event_collection", @"target_property": @"something"}];
 
     XCTestExpectation* responseArrived = [self expectationWithDescription:@"response of async request has arrived"];
-    [client runMultiAnalysisWithQueries:@[countQuery, averageQuery]
-                      completionHandler:^(NSData* queryResponseData, NSURLResponse* response, NSError* error) {
+    [client runAsyncMultiAnalysisWithQueries:@[countQuery, averageQuery]
+                              withCompletion:^(NSData* queryResponseData, NSURLResponse* response, NSError* error) {
         // Check for the sdk version header
         [urlSessionMock verify];
 

--- a/KeenSwiftClientExample/KeenSwiftClientExample/ThirdViewController.swift
+++ b/KeenSwiftClientExample/KeenSwiftClientExample/ThirdViewController.swift
@@ -45,7 +45,7 @@ import UIKit
 
         // Async querying
         let countQuery: KIOQuery = KIOQuery(query:"count", andPropertiesDictionary:["event_collection": "tab_views", "timeframe": "this_7_days"]);
-        KeenClient.shared().runAsyncQuery(countQuery, withCompletion: countQueryCompleted);
+        KeenClient.shared().runAsyncQuery(countQuery, completionHandler: countQueryCompleted);
 
         // Multi-analysis querying example
         /*

--- a/KeenSwiftClientExample/KeenSwiftClientExample/ThirdViewController.swift
+++ b/KeenSwiftClientExample/KeenSwiftClientExample/ThirdViewController.swift
@@ -9,17 +9,17 @@
 import UIKit
 
 @objc(ThirdViewController) class ThirdViewController: UIViewController {
-    
+
     @IBOutlet weak var resultTextView: UITextView!;
-    
+
     @IBAction func sendQueryButtonPressed(_ sender: AnyObject) {
-        
+
         let countQueryCompleted = { (responseData: Data?, returningResponse: URLResponse?, error: Error?) -> Void in
             do {
                 let responseDictionary: NSDictionary? = try JSONSerialization.jsonObject(with: responseData!, options: JSONSerialization.ReadingOptions.mutableContainers) as? NSDictionary;
-                
+
                 NSLog("response: %@", responseDictionary!);
-                
+
                 if error != nil {
                     self.resultTextView.text = "Error! 😞 \n\n error: \(error?.localizedDescription)";
                 } else if let errorCode = responseDictionary!.object(forKey: "error_code"),
@@ -27,55 +27,54 @@ import UIKit
                     self.resultTextView.text = "Failure! 😞 \n\n error code: \(errorCode)\n\n message: \(errorMessage)";
                 } else {
                     let result: NSNumber = responseDictionary!.object(forKey: "result") as! NSNumber;
-                    
+
                     NSLog("result: %@", result);
-                    
+
                     // Get result value when querying with group_by property
                     let resultArray: NSArray = responseDictionary!.object(forKey: "result") as! NSArray;
                     let resultDictionary: NSDictionary = resultArray[0] as! NSDictionary;
                     let resultValue: NSNumber = resultDictionary.object(forKey: "result") as! NSNumber;
                     NSLog("resultValue: %@", resultValue);
-                    
+
                     self.resultTextView.text = "Success! 😄 \n\n response: \(responseDictionary!.description)";
                 }
             } catch let error as NSError {
                 print("Error: \(error.localizedDescription)")
             }
         }
-        
+
         // Async querying
         let countQuery: KIOQuery = KIOQuery(query:"count", andPropertiesDictionary:["event_collection": "tab_views", "timeframe": "this_7_days"]);
-        
-        KeenClient.shared().runAsyncQuery(countQuery, block: countQueryCompleted);
-        
+        KeenClient.shared().runAsyncQuery(countQuery, withCompletion: countQueryCompleted);
+
         // Multi-analysis querying example
         /*
         let countUniqueQuery: KIOQuery = KIOQuery(query:"count_unique", andPropertiesDictionary:["event_collection": "collection", "target_property": "key", "timeframe": "this_7_days"]);
-        
+
         countQuery.queryName = "count_query";
         countUniqueQuery.queryName = "count_unique_query";
-        
+
         KeenClient.shared().runAsyncMultiAnalysis(withQueries: [countQuery, countUniqueQuery], block: countQueryCompleted);
         */
-        
+
         // Funnel example
         /*
         let funnelQuery: KIOQuery = KIOQuery(query:"funnel", andPropertiesDictionary:["timeframe": "this_7_days", "steps": [["event_collection": "user_signed_up", "actor_property": "user.id"], ["event_collection": "user_completed_profile", "actor_property": "user.id"]]]);
-        
+
         KeenClient.shared().runAsyncQuery(funnelQuery, block: countQueryCompleted);
         */
     }
-    
+
     override func viewDidLoad() {
         super.viewDidLoad()
     }
-    
+
     override func didReceiveMemoryWarning() {
         super.didReceiveMemoryWarning()
         // Dispose of any resources that can be recreated.
     }
     override func viewWillAppear(_ animated: Bool) {
-        
+
         super.viewWillAppear(animated);
         let theEvent = ["view_name": "third view Swift", "action": "going to"];
         do {
@@ -83,9 +82,9 @@ import UIKit
         } catch _ {
         };
     }
-    
+
     override func viewWillDisappear(_ animated : Bool) {
-        
+
         super.viewWillDisappear(animated);
         let theEvent = ["view_name" : "third view Swift", "action" : "leaving from"];
         do {
@@ -93,6 +92,6 @@ import UIKit
         } catch _ {
         };
     }
-    
+
 }
 


### PR DESCRIPTION
Deprecates a few selectors on KeenClient that shouldn't be there. They were exposed only for testing. Also, don't use those methods for testing, use the full async method that uses the queue.

Rename a few methods to have more Obj-C style names, deprecating the old methods. They're still there so this can go in a minor release. All deprecated methods should be cleaned out when we do a major revision.