### PR TITLE
General cleanup and Objective-C modernization

### DIFF
--- a/KeenClient/HTTPCodes.m
+++ b/KeenClient/HTTPCodes.m
@@ -18,7 +18,6 @@
 #pragma mark Code descriptions
 
 + (NSString *)descriptionForCode:(HTTPCode)code {
-    
     NSString *description = [NSString stringWithFormat:@"Unknown status code: %lu", (unsigned long)code];
     
     switch (code) {

--- a/KeenClient/KIODBStore.h
+++ b/KeenClient/KIODBStore.h
@@ -13,7 +13,7 @@
  /**
   Singleton instance of this class.
   */
-+ (KIODBStore*)sharedInstance;
++ (KIODBStore *)sharedInstance;
 
  /**
   Reset any pending events so they can be resent.
@@ -60,7 +60,7 @@
 
   @param eventId The id of the event to delete.
   */
-- (void)deleteEvent: (NSNumber *)eventId;
+- (void)deleteEvent:(NSNumber *)eventId;
 
  /**
   Delete all events from the store
@@ -88,7 +88,7 @@
  @param eventCollection Your event collection.
  @param projectID Your project ID.
  */
-- (BOOL)addQuery:(NSData *)queryData queryType:(NSString*)queryType collection:(NSString *)eventCollection projectID:(NSString *)projectID;
+- (BOOL)addQuery:(NSData *)queryData queryType:(NSString *)queryType collection:(NSString *)eventCollection projectID:(NSString *)projectID;
 
 /**
  Get a dictionary of the found query parameters.

--- a/KeenClient/KIODBStore.m
+++ b/KeenClient/KIODBStore.m
@@ -50,16 +50,17 @@
 - (instancetype)init {
     self = [super init];
 
-    if(self) {
+    if (self) {
         keen_dbname = NULL;
         dbIsOpen = NO;
         [self openAndInitDB];
     }
+
     return self;
 }
 
-+ (KIODBStore*)sharedInstance {
-    static KIODBStore* s_sharedDBStore = nil;
++ (KIODBStore *)sharedInstance {
+    static KIODBStore *s_sharedDBStore = nil;
     
     // This black magic ensures this block
     // is dispatched only once over the lifetime
@@ -80,7 +81,7 @@
 
 # pragma mark Database Methods
 
-- (NSString*) getSqliteFullFileName {
+- (NSString *)getSqliteFullFileName {
     NSString *libraryPath = [NSSearchPathForDirectoriesInDomains(NSLibraryDirectory, NSUserDomainMask, YES) objectAtIndex:0];
     return [libraryPath stringByAppendingPathComponent:@"keenEvents.sqlite"];
 }
@@ -88,7 +89,7 @@
 - (BOOL)openDB {
     __block BOOL wasOpened = NO;
     
-    NSString* dbFile = [self getSqliteFullFileName];
+    NSString *dbFile = [self getSqliteFullFileName];
     KCLogInfo(@"%@", dbFile);
     
     // we're going to use a queue for all database operations, so let's create it
@@ -103,10 +104,9 @@
 	
         int openDBResult = keen_io_sqlite3_open([dbFile UTF8String], &keen_dbname);
         if (openDBResult != SQLITE_OK) {
-            if(openDBResult == SQLITE_CORRUPT) {
+            if (openDBResult == SQLITE_CORRUPT) {
                 wasOpened = [self deleteAndRecreateCorruptDB];
-            }
-            else {
+            } else {
                 [self handleSQLiteFailure:@"create database"];
             }
         } else {
@@ -121,13 +121,12 @@
 - (BOOL)deleteAndRecreateCorruptDB {
     BOOL wasOpened = NO;
     // Close the existing db if it's open
-    if (NULL != keen_dbname)
-    {
+    if (keen_dbname) {
         keen_io_sqlite3_close(keen_dbname);
         keen_dbname = NULL;
     }
     
-    NSString* dbFile = [self getSqliteFullFileName];
+    NSString *dbFile = [self getSqliteFullFileName];
     KCLogError(@"Deleting corrupt db: %@", dbFile);
     [[NSFileManager defaultManager] removeItemAtPath:dbFile error:nil];
     
@@ -143,11 +142,11 @@
 }
 
 - (BOOL)openAndInitDB {
-    if(!dbIsOpen) {
+    if (!dbIsOpen) {
         if (![self openDB]) {
             return false;
         } else {
-            if(![self createTables]) {
+            if (![self createTables]) {
                 KCLogError(@"Failed to create SQLite table!");
                 [self closeDB];
                 return false;
@@ -169,7 +168,7 @@
 
 - (void)closeDB {
     // Free all the prepared statements. This is safe on null pointers.
-    if(dbIsOpen) {
+    if (dbIsOpen) {
         self.dbQueue = nil;
         
         keen_io_sqlite3_finalize(insert_event_stmt);
@@ -215,15 +214,13 @@
         char *eventsError;
         NSString *createEventsTableSQL = [NSString stringWithFormat:@"CREATE TABLE IF NOT EXISTS 'events' (ID INTEGER PRIMARY KEY AUTOINCREMENT, collection TEXT, projectID TEXT, eventData BLOB, pending INTEGER, dateCreated TIMESTAMP DEFAULT CURRENT_TIMESTAMP);"];
         int result = SQLITE_FAIL;
-        for (int i = 0; i < 2; ++i)
-        {
+        for (int i = 0; i < 2; ++i) {
             // The database is loaded on demand and this is the first time we use it, so here
             // is where we're likely to actually notice corruption. Handle it by deleting the
             // corrupt db and creating a new one.
             result = keen_io_sqlite3_exec(keen_dbname, [createEventsTableSQL UTF8String], NULL, NULL, &eventsError);
             if (result == SQLITE_CORRUPT) {
-                if (![self deleteAndRecreateCorruptDB])
-                {
+                if (![self deleteAndRecreateCorruptDB]) {
                     KCLogError(@"Failed to replace corrupt db while creating events table: %@", [NSString stringWithCString:eventsError encoding:NSUTF8StringEncoding]);
                     keen_io_sqlite3_free(eventsError); // Free that error message
                     [self closeDB];
@@ -261,11 +258,11 @@
     // get current database version of schema
     static keen_io_sqlite3_stmt *stmt_version;
     
-    if(keen_io_sqlite3_prepare_v2(keen_dbname, "PRAGMA user_version;", -1, &stmt_version, NULL) != SQLITE_OK) {
+    if (keen_io_sqlite3_prepare_v2(keen_dbname, "PRAGMA user_version;", -1, &stmt_version, NULL) != SQLITE_OK) {
         return -1;
     }
     
-    while(keen_io_sqlite3_step(stmt_version) == SQLITE_ROW) {
+    while (keen_io_sqlite3_step(stmt_version) == SQLITE_ROW) {
         databaseVersion = keen_io_sqlite3_column_int(stmt_version, 0);
     }
     keen_io_sqlite3_finalize(stmt_version);
@@ -309,11 +306,11 @@
     return wasMigrated;
 }
 
--(BOOL)migrateFromVersion: (int)userVersion {
+- (BOOL)migrateFromVersion:(int)userVersion {
     // this is really more of a while loop, but we use a for loop with a limit to avoid
     // getting stuck in an infinite loop if there is a bug in the loop breaking logic
-    for(int i = 0; i < 1000; i++) {
-        if(![self beginTransaction]) {
+    for (int i = 0; i < 1000; i++) {
+        if (![self beginTransaction]) {
             // deal with error?
             KCLogError(@"Migration failed to begin a transaction with userVersion = %d.", userVersion);
             return NO;
@@ -433,7 +430,7 @@
 - (BOOL)addEvent:(NSData *)eventData collection:(NSString *)eventCollection projectID:(NSString *)projectID {
     __block BOOL wasAdded = NO;
 
-    if(![self checkOpenDB:@"DB is closed, skipping addEvent"]) {
+    if (![self checkOpenDB:@"DB is closed, skipping addEvent"]) {
         return wasAdded;
     }
     
@@ -473,12 +470,12 @@
     // Create a dictionary to hold the contents of our select.
     __block NSMutableDictionary *events = [NSMutableDictionary dictionary];
 
-    if(![self checkOpenDB:@"DB is closed, skipping getEvents"]) {
+    if (![self checkOpenDB:@"DB is closed, skipping getEvents"]) {
         return events;
     }
     
     // reset pending events, if necessary
-    if([self hasPendingEventsWithProjectID:projectID]) {
+    if ([self hasPendingEventsWithProjectID:projectID]) {
         [self resetPendingEventsWithProjectID:projectID];
     }
     
@@ -490,7 +487,7 @@
             return;
         }
         
-        if(keen_io_sqlite3_bind_int64(find_event_stmt, 2, maxAttempts) != SQLITE_OK) {
+        if (keen_io_sqlite3_bind_int64(find_event_stmt, 2, maxAttempts) != SQLITE_OK) {
             [self handleSQLiteFailure:@"bind coll to add event statement"];
             return;
         }
@@ -508,7 +505,7 @@
             NSData *data = [[NSData alloc] initWithBytes:dataPtr length:dataSize];
 
             // Bind and mark the event pending.
-            if(keen_io_sqlite3_bind_int64(make_pending_event_stmt, 1, eventId) != SQLITE_OK) {
+            if (keen_io_sqlite3_bind_int64(make_pending_event_stmt, 1, eventId) != SQLITE_OK) {
                 [self handleSQLiteFailure:@"bind int for make pending"];
                 return;
             }
@@ -536,7 +533,7 @@
 }
 
 - (void)resetPendingEventsWithProjectID:(NSString *)projectID {
-    if(![self checkOpenDB:@"DB is closed, skipping resetPendingEvents"]) {
+    if (![self checkOpenDB:@"DB is closed, skipping resetPendingEvents"]) {
         return;
     }
     
@@ -558,7 +555,7 @@
 - (BOOL)hasPendingEventsWithProjectID:(NSString *)projectID {
     BOOL hasRows = NO;
 
-    if(![self checkOpenDB:@"DB is closed, skipping hasPendingEvents"]) {
+    if (![self checkOpenDB:@"DB is closed, skipping hasPendingEvents"]) {
         return hasRows;
     }
 
@@ -571,7 +568,7 @@
 - (NSUInteger)getPendingEventCountWithProjectID:(NSString *)projectID {
     __block NSUInteger eventCount = 0;
 
-    if(![self checkOpenDB:@"DB is closed, skipping getPendingEventcount"]) {
+    if (![self checkOpenDB:@"DB is closed, skipping getPendingEventcount"]) {
         return eventCount;
     }
 
@@ -598,7 +595,7 @@
 - (NSUInteger)getTotalEventCountWithProjectID:(NSString *)projectID {
     __block NSUInteger eventCount = 0;
 
-    if(![self checkOpenDB:@"DB is closed, skipping getTotalEventCount"]) {
+    if (![self checkOpenDB:@"DB is closed, skipping getTotalEventCount"]) {
         return eventCount;
     }
 
@@ -623,7 +620,7 @@
 }
 
 - (void)deleteEvent:(NSNumber *)eventId {
-    if(![self checkOpenDB:@"DB is closed, skipping deleteEvent"]) {
+    if (![self checkOpenDB:@"DB is closed, skipping deleteEvent"]) {
         return;
     }
     
@@ -642,7 +639,7 @@
 }
 
 - (void)deleteAllEvents {
-    if(![self checkOpenDB:@"DB is closed, skipping deleteEvent"]) {
+    if (![self checkOpenDB:@"DB is closed, skipping deleteEvent"]) {
         return;
     }
     
@@ -657,7 +654,7 @@
 }
 
 - (void)deleteEventsFromOffset:(NSNumber *)offset {
-    if(![self checkOpenDB:@"DB is closed, skipping deleteEvent"]) {
+    if (![self checkOpenDB:@"DB is closed, skipping deleteEvent"]) {
         return;
     }
 
@@ -676,7 +673,7 @@
 }
 
 - (void)incrementEventUploadAttempts:(NSNumber *)eventId {
-    if(![self checkOpenDB:@"DB is closed, skipping incrementAttempts"]) {
+    if (![self checkOpenDB:@"DB is closed, skipping incrementAttempts"]) {
         return;
     }
 
@@ -695,7 +692,7 @@
 }
 
 - (void)purgePendingEventsWithProjectID:(NSString *)projectID {
-    if(![self checkOpenDB:@"DB is closed, skipping purgePendingEvents"]) {
+    if (![self checkOpenDB:@"DB is closed, skipping purgePendingEvents"]) {
         return;
     }
 
@@ -719,7 +716,7 @@
 - (BOOL)addQuery:(NSData *)queryData queryType:(NSString *)queryType collection:(NSString *)eventCollection projectID:(NSString *)projectID {
     __block BOOL wasAdded = NO;
 
-    if(![self checkOpenDB:@"DB is closed, skipping addQuery"]) {
+    if (![self checkOpenDB:@"DB is closed, skipping addQuery"]) {
         return wasAdded;
     }
 
@@ -765,7 +762,7 @@
     // Create a dictionary to hold the contents of our select.
     __block NSMutableDictionary *query = nil;
     
-    if(![self checkOpenDB:@"DB is closed, skipping getQuery"]) {
+    if (![self checkOpenDB:@"DB is closed, skipping getQuery"]) {
         return query;
     }
     
@@ -833,7 +830,7 @@
 - (BOOL)incrementQueryAttempts:(NSNumber *)queryID {
     __block BOOL wasUpdated = NO;
     
-    if(![self checkOpenDB:@"DB is closed, skipping query increment attempt"]) {
+    if (![self checkOpenDB:@"DB is closed, skipping query increment attempt"]) {
         return wasUpdated;
     }
     
@@ -857,7 +854,7 @@
 
 - (void)findOrUpdateQuery:(NSData *)queryData queryType:(NSString *)queryType collection:(NSString *)eventCollection projectID:(NSString *)projectID {
     NSMutableDictionary *returnedQuery = [self getQuery:queryData queryType:queryType collection:eventCollection projectID:projectID];
-    if(returnedQuery != nil) {
+    if (returnedQuery != nil) {
         // if query is found, update query attempts
         [self incrementQueryAttempts:[returnedQuery objectForKey:@"queryID"]];
     } else {
@@ -869,7 +866,7 @@
 - (NSUInteger)getTotalQueryCountWithProjectID:(NSString *)projectID {
     __block NSUInteger queryCount = 0;
     
-    if(![self checkOpenDB:@"DB is closed, skipping getTotalQueryCount"]) {
+    if (![self checkOpenDB:@"DB is closed, skipping getTotalQueryCount"]) {
         return queryCount;
     }
 
@@ -902,7 +899,7 @@
     
     __block BOOL hasFoundQueryWithMaxAttempts = NO;
     
-    if(![self checkOpenDB:@"DB is closed, skipping hasQueryWithMaxAttempts"]) {
+    if (![self checkOpenDB:@"DB is closed, skipping hasQueryWithMaxAttempts"]) {
         return hasFoundQueryWithMaxAttempts;
     }
     
@@ -955,7 +952,7 @@
 }
 
 - (void)deleteAllQueries {
-    if(![self checkOpenDB:@"DB is closed, skipping deleteAllQueries"]) {
+    if (![self checkOpenDB:@"DB is closed, skipping deleteAllQueries"]) {
         return;
     }
     
@@ -970,7 +967,7 @@
 }
 
 - (void)deleteQueriesOlderThan:(NSNumber *)seconds {
-    if(![self checkOpenDB:@"DB is closed, skipping deleteQueries"]) {
+    if (![self checkOpenDB:@"DB is closed, skipping deleteQueries"]) {
         return;
     }
     
@@ -993,7 +990,7 @@
 # pragma mark - Helper Methods -
 
 - (BOOL)checkOpenDB:(NSString *)failureMessage {
-    if(![self openAndInitDB]) {
+    if (![self openAndInitDB]) {
         KCLogError(@"%@", failureMessage);
         return false;
     }
@@ -1002,7 +999,7 @@
 }
 
 - (BOOL)prepareSQLStatement:(keen_io_sqlite3_stmt **)sqlStatement sqlQuery:(char *)sqlQuery failureMessage:(NSString *)failureMessage {
-    if(keen_io_sqlite3_prepare_v2(keen_dbname, sqlQuery, -1, sqlStatement, NULL) != SQLITE_OK) {
+    if (keen_io_sqlite3_prepare_v2(keen_dbname, sqlQuery, -1, sqlStatement, NULL) != SQLITE_OK) {
         [self handleSQLiteFailure:failureMessage];
         return NO;
     }
@@ -1019,64 +1016,64 @@
     // EVENT STATEMENTS
     
     // This statement inserts events into the table.
-    if(![self prepareSQLStatement:&insert_event_stmt sqlQuery:"INSERT INTO events (projectID, collection, eventData, pending, attempts) VALUES (?, ?, ?, 0, 0)" failureMessage:@"prepare insert event statement"]) return NO;
+    if (![self prepareSQLStatement:&insert_event_stmt sqlQuery:"INSERT INTO events (projectID, collection, eventData, pending, attempts) VALUES (?, ?, ?, 0, 0)" failureMessage:@"prepare insert event statement"]) return NO;
     
     // This statement finds non-pending events in the table.
-    if(![self prepareSQLStatement:&find_event_stmt sqlQuery:"SELECT id, collection, eventData FROM events WHERE pending=0 AND projectID=? AND attempts<?" failureMessage:@"prepare find non-pending events statement"]) return NO;
+    if (![self prepareSQLStatement:&find_event_stmt sqlQuery:"SELECT id, collection, eventData FROM events WHERE pending=0 AND projectID=? AND attempts<?" failureMessage:@"prepare find non-pending events statement"]) return NO;
     
     // This statement counts the total number of events (pending or not)
-    if(![self prepareSQLStatement:&count_all_events_stmt sqlQuery:"SELECT count(*) FROM events WHERE projectID=?" failureMessage:@"prepare count all events statement"]) return NO;
+    if (![self prepareSQLStatement:&count_all_events_stmt sqlQuery:"SELECT count(*) FROM events WHERE projectID=?" failureMessage:@"prepare count all events statement"]) return NO;
     
     // This statement counts the number of pending events.
-    if(![self prepareSQLStatement:&count_pending_events_stmt sqlQuery:"SELECT count(*) FROM events WHERE pending=1 AND projectID=?" failureMessage:@"prepare count pending events statement"]) return NO;
+    if (![self prepareSQLStatement:&count_pending_events_stmt sqlQuery:"SELECT count(*) FROM events WHERE pending=1 AND projectID=?" failureMessage:@"prepare count pending events statement"]) return NO;
     
     // This statement marks an event as pending.
-    if(![self prepareSQLStatement:&make_pending_event_stmt sqlQuery:"UPDATE events SET pending=1 WHERE id=?" failureMessage:@"prepare mark event as pending statement"]) return NO;
+    if (![self prepareSQLStatement:&make_pending_event_stmt sqlQuery:"UPDATE events SET pending=1 WHERE id=?" failureMessage:@"prepare mark event as pending statement"]) return NO;
     
     // This statement resets pending events back to normal.
-    if(![self prepareSQLStatement:&reset_pending_events_stmt sqlQuery:"UPDATE events SET pending=0 WHERE projectID=?" failureMessage:@"prepare reset pending statement"]) return NO;
+    if (![self prepareSQLStatement:&reset_pending_events_stmt sqlQuery:"UPDATE events SET pending=0 WHERE projectID=?" failureMessage:@"prepare reset pending statement"]) return NO;
     
     // This statement purges all pending events.
-    if(![self prepareSQLStatement:&purge_events_stmt sqlQuery:"DELETE FROM events WHERE pending=1 AND projectID=?" failureMessage:@"prepare purge pending events statement"]) return NO;
+    if (![self prepareSQLStatement:&purge_events_stmt sqlQuery:"DELETE FROM events WHERE pending=1 AND projectID=?" failureMessage:@"prepare purge pending events statement"]) return NO;
     
     // This statement deletes a specific event.
-    if(![self prepareSQLStatement:&delete_event_stmt sqlQuery:"DELETE FROM events WHERE id=?" failureMessage:@"prepare delete specific event statement"]) return NO;
+    if (![self prepareSQLStatement:&delete_event_stmt sqlQuery:"DELETE FROM events WHERE id=?" failureMessage:@"prepare delete specific event statement"]) return NO;
     
     // This statement deletes all events.
-    if(![self prepareSQLStatement:&delete_all_events_stmt sqlQuery:"DELETE FROM events" failureMessage:@"prepare delete all events statement"]) return NO;
+    if (![self prepareSQLStatement:&delete_all_events_stmt sqlQuery:"DELETE FROM events" failureMessage:@"prepare delete all events statement"]) return NO;
     
     // This statement deletes old events at a given offset.
-    if(![self prepareSQLStatement:&age_out_events_stmt sqlQuery:"DELETE FROM events WHERE id <= (SELECT id FROM events ORDER BY id DESC LIMIT 1 OFFSET ?)" failureMessage:@"prepare delete old events at offset statement"]) return NO;
+    if (![self prepareSQLStatement:&age_out_events_stmt sqlQuery:"DELETE FROM events WHERE id <= (SELECT id FROM events ORDER BY id DESC LIMIT 1 OFFSET ?)" failureMessage:@"prepare delete old events at offset statement"]) return NO;
     
     // This statement increments the attempts count of an event.
-    if(![self prepareSQLStatement:&increment_event_attempts_statement sqlQuery:"UPDATE events SET attempts = attempts + 1 WHERE id=?" failureMessage:@"prepare event increment attempt statement"]) return NO;
+    if (![self prepareSQLStatement:&increment_event_attempts_statement sqlQuery:"UPDATE events SET attempts = attempts + 1 WHERE id=?" failureMessage:@"prepare event increment attempt statement"]) return NO;
     
     // This statement deletes events exceeding a max attempt limit.
-    if(![self prepareSQLStatement:&delete_too_many_attempts_events_statement sqlQuery:"DELETE FROM events WHERE attempts >= ?" failureMessage:@"prepare delete max attempts events statement"]) return NO;
+    if (![self prepareSQLStatement:&delete_too_many_attempts_events_statement sqlQuery:"DELETE FROM events WHERE attempts >= ?" failureMessage:@"prepare delete max attempts events statement"]) return NO;
 
     
     // QUERY STATEMENTS
     
     // This statement inserts queries into the table.
-    if(![self prepareSQLStatement:&insert_query_stmt sqlQuery:"INSERT INTO queries (projectID, collection, queryData, queryType, attempts) VALUES (?, ?, ?, ?, 0)" failureMessage:@"prepare insert query statement"]) return NO;
+    if (![self prepareSQLStatement:&insert_query_stmt sqlQuery:"INSERT INTO queries (projectID, collection, queryData, queryType, attempts) VALUES (?, ?, ?, ?, 0)" failureMessage:@"prepare insert query statement"]) return NO;
     
     // This statement counts the total number of queries
-    if(![self prepareSQLStatement:&count_all_queries_stmt sqlQuery:"SELECT count(*) FROM queries WHERE projectID=?" failureMessage:@"prepare count all queries statement"]) return NO;
+    if (![self prepareSQLStatement:&count_all_queries_stmt sqlQuery:"SELECT count(*) FROM queries WHERE projectID=?" failureMessage:@"prepare count all queries statement"]) return NO;
  
     // This statement searches for and returns a query.
-    if(![self prepareSQLStatement:&get_query_stmt sqlQuery:"SELECT id, collection, queryData, queryType, attempts FROM queries WHERE projectID=? AND collection=? AND queryData=? AND queryType=?" failureMessage:@"prepare find query statement"]) return NO;
+    if (![self prepareSQLStatement:&get_query_stmt sqlQuery:"SELECT id, collection, queryData, queryType, attempts FROM queries WHERE projectID=? AND collection=? AND queryData=? AND queryType=?" failureMessage:@"prepare find query statement"]) return NO;
     
     // This statement searches for and returns a query given an attempts value.
-    if(![self prepareSQLStatement:&get_query_with_attempts_stmt sqlQuery:"SELECT id FROM queries WHERE projectID=? AND collection=? AND queryData=? AND queryType=? AND attempts >=?" failureMessage:@"prepare find query with attempts statement"]) return NO;
+    if (![self prepareSQLStatement:&get_query_with_attempts_stmt sqlQuery:"SELECT id FROM queries WHERE projectID=? AND collection=? AND queryData=? AND queryType=? AND attempts >=?" failureMessage:@"prepare find query with attempts statement"]) return NO;
     
     // This statement increments the attempts count of a query.
-    if(![self prepareSQLStatement:&increment_query_attempts_statement sqlQuery:"UPDATE queries SET attempts = attempts + 1 WHERE id=?" failureMessage:@"prepare query increment attempt statement"]) return NO;
+    if (![self prepareSQLStatement:&increment_query_attempts_statement sqlQuery:"UPDATE queries SET attempts = attempts + 1 WHERE id=?" failureMessage:@"prepare query increment attempt statement"]) return NO;
     
     // This statement deletes all queries.
-    if(![self prepareSQLStatement:&delete_all_queries_stmt sqlQuery:"DELETE FROM queries" failureMessage:@"prepare delete all queries statement"]) return NO;
+    if (![self prepareSQLStatement:&delete_all_queries_stmt sqlQuery:"DELETE FROM queries" failureMessage:@"prepare delete all queries statement"]) return NO;
     
     // This statement deletes old queries at a given time.
-    if(![self prepareSQLStatement:&age_out_queries_stmt sqlQuery:"DELETE FROM queries WHERE dateCreated <= datetime('now', ?)" failureMessage:@"prepare delete old queries at seconds statement"]) return NO;
+    if (![self prepareSQLStatement:&age_out_queries_stmt sqlQuery:"DELETE FROM queries WHERE dateCreated <= datetime('now', ?)" failureMessage:@"prepare delete old queries at seconds statement"]) return NO;
     
     return YES;
 }
@@ -1086,8 +1083,7 @@
           msg, [NSString stringWithCString:keen_io_sqlite3_errmsg(keen_dbname) encoding:NSUTF8StringEncoding]);
     int result = keen_io_sqlite3_errcode(keen_dbname);
     [self closeDB];
-    if (SQLITE_CORRUPT == result)
-    {
+    if (SQLITE_CORRUPT == result) {
         NSString* dbFile = [self getSqliteFullFileName];
         KCLogError(@"Deleting corrupt db: %@", dbFile);
         [[NSFileManager defaultManager] removeItemAtPath:dbFile error:nil];

--- a/KeenClient/KIODBStore.m
+++ b/KeenClient/KIODBStore.m
@@ -60,7 +60,7 @@
 }
 
 + (KIODBStore *)sharedInstance {
-    static KIODBStore *s_sharedDBStore = nil;
+    static KIODBStore *s_sharedDBStore;
     
     // This black magic ensures this block
     // is dispatched only once over the lifetime
@@ -71,7 +71,7 @@
     // for the block to complete.
     static dispatch_once_t predicate = {0};
     dispatch_once(&predicate, ^{
-        s_sharedDBStore = [[KIODBStore alloc] init];
+        s_sharedDBStore = [KIODBStore new];
     });
     
     return s_sharedDBStore;
@@ -275,7 +275,7 @@
     return databaseVersion;
 }
 
-- (BOOL)setUserVersion: (int)userVersion {
+- (BOOL)setUserVersion:(int)userVersion {
     char *err;
     NSString *sql = [NSString stringWithFormat:@"PRAGMA user_version = %d;", userVersion];
     if (keen_io_sqlite3_exec(keen_dbname, [sql UTF8String], NULL, NULL, &err) != SQLITE_OK) {

--- a/KeenClient/KIOFileStore.h
+++ b/KeenClient/KIOFileStore.h
@@ -13,11 +13,11 @@
 /**
  Migrate data from old file-based store if present
  */
-+ (void)maybeMigrateDataFromFileStore:(NSString*)projectID;
++ (void)maybeMigrateDataFromFileStore:(NSString *)projectID;
 
 /**
  Migrate data from old file-based store
  */
-+ (void)importFileDataWithProjectID:(NSString*)projectID;
++ (void)importFileDataWithProjectID:(NSString *)projectID;
 
 @end

--- a/KeenClient/KIOFileStore.m
+++ b/KeenClient/KIOFileStore.m
@@ -118,7 +118,7 @@
         // that out first.
         if ([fileManager fileExistsAtPath:rootPath]) {
             // declare an error object
-            NSError *error = nil;
+            NSError *error;
 
             // iterate through each directory
             NSArray *directories = [self keenSubDirectoriesForProjectID:projectID];

--- a/KeenClient/KIOFileStore.m
+++ b/KeenClient/KIOFileStore.m
@@ -15,48 +15,48 @@
 @interface KIOFileStore ()
 
 // Get the cache directory
-+ (NSString*)cacheDirectory;
++ (NSString *)cacheDirectory;
 
 // Get the directory for storage of events for a given project
-+ (NSString*)keenDirectoryForProjectID:(NSString*)projectID;
++ (NSString *)keenDirectoryForProjectID:(NSString *)projectID;
 
 // Get subdirectories under path for a given project
-+ (NSArray*)keenSubDirectoriesForProjectID:(NSString*)projectID;
++ (NSArray *)keenSubDirectoriesForProjectID:(NSString *)projectID;
 
 // Get the file contents at a given path
-+ (NSArray*)contentsAtPath:(NSString*)path;
++ (NSArray *)contentsAtPath:(NSString *)path;
 
 // Get the event directory for a collection and project
-+ (NSString*)eventDirectoryForProjectID:(NSString*)projectID
-                          andCollection:(NSString*)collection;
++ (NSString *)eventDirectoryForProjectID:(NSString *)projectID
+                          andCollection:(NSString *)collection;
 
 @end
 
 
 @implementation KIOFileStore
 
-+ (NSString*)cacheDirectory {
-    NSArray* paths = NSSearchPathForDirectoriesInDomains(NSCachesDirectory, NSUserDomainMask, YES);
-    NSString* documentsDirectory = [paths objectAtIndex:0];
++ (NSString *)cacheDirectory {
+    NSArray *paths = NSSearchPathForDirectoriesInDomains(NSCachesDirectory, NSUserDomainMask, YES);
+    NSString *documentsDirectory = [paths objectAtIndex:0];
     return documentsDirectory;
 }
 
 
-+ (NSString*)keenDirectoryForProjectID:(NSString*)projectID {
-    NSString* keenDirPath = [[self cacheDirectory] stringByAppendingPathComponent:@"keen"];
++ (NSString *)keenDirectoryForProjectID:(NSString *)projectID {
+    NSString *keenDirPath = [[self cacheDirectory] stringByAppendingPathComponent:@"keen"];
     return [keenDirPath stringByAppendingPathComponent:projectID];
 }
 
 
-+ (NSArray*)keenSubDirectoriesForProjectID:(NSString*)projectID {
++ (NSArray *)keenSubDirectoriesForProjectID:(NSString *)projectID {
     return [self contentsAtPath:[self keenDirectoryForProjectID:projectID]];
 }
 
 
-+ (NSArray*)contentsAtPath:(NSString *)path {
-    NSFileManager* fileManager = [NSFileManager defaultManager];
-    NSError* error = nil;
-    NSArray* files = [fileManager contentsOfDirectoryAtPath:path error:&error];
++ (NSArray *)contentsAtPath:(NSString *)path {
+    NSFileManager *fileManager = [NSFileManager defaultManager];
+    NSError *error;
+    NSArray *files = [fileManager contentsOfDirectoryAtPath:path error:&error];
     if (error) {
         KCLogError(@"An error occurred when listing directory (%@) contents: %@", path, [error localizedDescription]);
         return nil;
@@ -100,7 +100,7 @@
 }
 
 
-+ (void)importFileDataWithProjectID:(NSString*)projectID {
++ (void)importFileDataWithProjectID:(NSString *)projectID {
     // Save a flag that we've done the FS import so we don't waste
     // time on it in the future.
     NSUserDefaults *defaults = [NSUserDefaults standardUserDefaults];
@@ -164,7 +164,7 @@
 }
 
 
-+ (void)maybeMigrateDataFromFileStore:(NSString*)projectID {
++ (void)maybeMigrateDataFromFileStore:(NSString *)projectID {
     NSUserDefaults *defaults = [NSUserDefaults standardUserDefaults];
 
     // Check if we've done an import before. (A missing value returns NO)

--- a/KeenClient/KIONetwork.h
+++ b/KeenClient/KIONetwork.h
@@ -15,24 +15,24 @@
 + (instancetype)sharedInstance;
 
 // Initialize the object
-- (instancetype)initWithURLSession:(NSURLSession*)urlSession
-                          andStore:(KIODBStore*)store;
+- (instancetype)initWithURLSession:(NSURLSession *)urlSession
+                          andStore:(KIODBStore *)store;
 
 // Upload events to keen
-- (void)sendEvents:(NSData*)data
-     withProjectID:(NSString*)projectID
-      withWriteKey:(NSString*)writeKey
+- (void)sendEvents:(NSData *)data
+     withProjectID:(NSString *)projectID
+      withWriteKey:(NSString *)writeKey
  completionHandler:(void (^)(NSData *data, NSURLResponse *response, NSError *error))completionHandler;
 
 // Run an analysis request
-- (void)runQuery:(KIOQuery*)keenQuery withProjectID:(NSString*)projectID
-     withReadKey:(NSString*)readKey
+- (void)runQuery:(KIOQuery *)keenQuery withProjectID:(NSString *)projectID
+     withReadKey:(NSString *)readKey
 completionHandler:(void (^)(NSData *data, NSURLResponse *response, NSError *error))completionHandler;
 
 // Run a multi-analysis request
-- (void)runMultiAnalysisWithQueries:(NSArray*)keenQueries
-                      withProjectID:(NSString*)projectID
-                        withReadKey:(NSString*)readKey
+- (void)runMultiAnalysisWithQueries:(NSArray *)keenQueries
+                      withProjectID:(NSString *)projectID
+                        withReadKey:(NSString *)readKey
                   completionHandler:(void (^)(NSData *data, NSURLResponse *response, NSError *error))completionHandler;
 
 
@@ -43,6 +43,6 @@ completionHandler:(void (^)(NSData *data, NSURLResponse *response, NSError *erro
 @property int queryTTL;
 
 // The NSURLSession instance to use for requests
-@property (nonatomic, readonly) NSURLSession* urlSession;
+@property (nonatomic, readonly) NSURLSession *urlSession;
 
 @end

--- a/KeenClient/KIONetwork.h
+++ b/KeenClient/KIONetwork.h
@@ -15,6 +15,7 @@
 + (instancetype)sharedInstance;
 
 // Initialize the object
+- (instancetype)init NS_UNAVAILABLE;
 - (instancetype)initWithURLSession:(NSURLSession *)urlSession
                           andStore:(KIODBStore *)store;
 

--- a/KeenClient/KIONetwork.m
+++ b/KeenClient/KIONetwork.m
@@ -22,14 +22,14 @@
  @param responseData The data returned from the server.
  @param query The query that was passed to the Keen API.
  */
-- (void)handleQueryAPIResponse:(NSURLResponse*)response
-                       andData:(NSData*)responseData
-                      andQuery:(KIOQuery*)query
-                  andProjectID:(NSString*)projectID;
+- (void)handleQueryAPIResponse:(NSURLResponse *)response
+                       andData:(NSData *)responseData
+                      andQuery:(KIOQuery *)query
+                  andProjectID:(NSString *)projectID;
 
-@property (nonatomic, readwrite) NSURLSession* urlSession;
+@property (nonatomic, readwrite) NSURLSession *urlSession;
 
-@property (nonatomic) KIODBStore* store;
+@property (nonatomic) KIODBStore *store;
 
 @end
 
@@ -37,7 +37,7 @@
 @implementation KIONetwork
 
 + (instancetype)sharedInstance {
-    static KIONetwork* s_sharedInstance = nil;
+    static KIONetwork *s_sharedInstance = nil;
 
     // This black magic ensures this block
     // is dispatched only once over the lifetime
@@ -62,10 +62,10 @@
 }
 
 
-- (instancetype)initWithURLSession:(NSURLSession*)urlSession
-                          andStore:(KIODBStore*)store {
+- (instancetype)initWithURLSession:(NSURLSession *)urlSession
+                          andStore:(KIODBStore *)store {
     self = [super init];
-    if (nil != self) {
+    if (self) {
         self.maxQueryAttempts = 10;
         self.queryTTL = 3600;
         self.urlSession = urlSession;
@@ -74,11 +74,11 @@
     return self;
 }
 
-- (NSMutableURLRequest*)createRequestWithUrl:(NSString*)urlString
-                                     andBody:(NSData*)body
-                                      andKey:(NSString*)key {
-    NSURL* url = [NSURL URLWithString:urlString];
-    NSMutableURLRequest* request = [NSMutableURLRequest requestWithURL:url
+- (NSMutableURLRequest *)createRequestWithUrl:(NSString *)urlString
+                                     andBody:(NSData *)body
+                                      andKey:(NSString *)key {
+    NSURL *url = [NSURL URLWithString:urlString];
+    NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:url
                                                            cachePolicy:NSURLRequestUseProtocolCachePolicy
                                                        timeoutInterval:30.0f];
     [request setHTTPMethod:@"POST"];
@@ -91,13 +91,13 @@
     return request;
 }
 
-- (void)executeRequest:(NSURLRequest*)request
-     completionHandler:(void (^)(NSData* data, NSURLResponse* response, NSError* error))completionHandler {
+- (void)executeRequest:(NSURLRequest *)request
+     completionHandler:(void (^)(NSData *data, NSURLResponse *response, NSError *error))completionHandler {
     NSURLSession* session = self.urlSession;
     [[session dataTaskWithRequest:request completionHandler:completionHandler] resume];
 }
 
-- (BOOL)hasQueryReachedMaxAttempts:(KIOQuery*)keenQuery withProjectID:(NSString*)projectID {
+- (BOOL)hasQueryReachedMaxAttempts:(KIOQuery *)keenQuery withProjectID:(NSString *)projectID {
     return [self.store hasQueryWithMaxAttempts:[keenQuery convertQueryToData]
                                      queryType:keenQuery.queryType
                                     collection:[keenQuery.propertiesDictionary objectForKey:@"event_collection"]
@@ -109,53 +109,53 @@
 # pragma mark Sync methods
 
 - (void)sendEvents:(NSData *)data
-     withProjectID:(NSString*)projectID
-      withWriteKey:(NSString*)writeKey
- completionHandler:(void (^)(NSData* data, NSURLResponse* response, NSError* error))completionHandler {
-    NSString* urlString = [NSString stringWithFormat:@"%@/%@/projects/%@/events",
+     withProjectID:(NSString *)projectID
+      withWriteKey:(NSString *)writeKey
+ completionHandler:(void (^)(NSData *data, NSURLResponse *response, NSError *error))completionHandler {
+    NSString *urlString = [NSString stringWithFormat:@"%@/%@/projects/%@/events",
                            kKeenServerAddress, kKeenApiVersion, projectID];
     KCLogVerbose(@"Sending request to: %@", urlString);
 
-    NSMutableURLRequest* request = [self createRequestWithUrl:urlString
+    NSMutableURLRequest *request = [self createRequestWithUrl:urlString
                                                       andBody:data
                                                        andKey:writeKey];
 
-    [self executeRequest:request
-       completionHandler:completionHandler];
+    [self executeRequest:request completionHandler:completionHandler];
 }
 
 
-- (void)runQuery:(KIOQuery*)keenQuery withProjectID:(NSString*)projectID
-                                        withReadKey:(NSString*)readKey
-                                  completionHandler:(void (^)(NSData* data, NSURLResponse* response, NSError* error))completionHandler {
+- (void)runQuery:(KIOQuery *)keenQuery withProjectID:(NSString *)projectID
+                                        withReadKey:(NSString *)readKey
+                                  completionHandler:(void (^)(NSData *data, NSURLResponse *response, NSError *error))completionHandler {
     BOOL hasQueryWithMaxAttempts = [self hasQueryReachedMaxAttempts:keenQuery withProjectID:projectID];
 
     if (hasQueryWithMaxAttempts) {
         KCLogWarn(@"Not running query because it failed over %d times", self.maxQueryAttempts);
-    } else {
-        NSString* urlString = [NSString stringWithFormat:@"%@/%@/projects/%@/queries/%@",
-                               kKeenServerAddress, kKeenApiVersion, projectID, keenQuery.queryType];
-        KCLogVerbose(@"Sending request to: %@", urlString);
-
-        NSMutableURLRequest* request = [self createRequestWithUrl:urlString
-                                                          andBody:[keenQuery convertQueryToData]
-                                                           andKey:readKey];
-
-        [self executeRequest:request
-           completionHandler:^(NSData* data, NSURLResponse* response, NSError* error) {
-            [self handleQueryAPIResponse:response
-                                 andData:data
-                                andQuery:keenQuery
-                            andProjectID:projectID];
-            completionHandler(data, response, error);
-        }];
+        return;
     }
+
+    NSString *urlString = [NSString stringWithFormat:@"%@/%@/projects/%@/queries/%@",
+                           kKeenServerAddress, kKeenApiVersion, projectID, keenQuery.queryType];
+    KCLogVerbose(@"Sending request to: %@", urlString);
+
+    NSMutableURLRequest *request = [self createRequestWithUrl:urlString
+                                                      andBody:[keenQuery convertQueryToData]
+                                                       andKey:readKey];
+
+    [self executeRequest:request
+       completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
+           [self handleQueryAPIResponse:response
+                                andData:data
+                               andQuery:keenQuery
+                           andProjectID:projectID];
+           completionHandler(data, response, error);
+       }];
 }
 
-- (void)handleQueryAPIResponse:(NSURLResponse*)response
-                       andData:(NSData*)responseData
-                      andQuery:(KIOQuery*)query
-                  andProjectID:(NSString*)projectID {
+- (void)handleQueryAPIResponse:(NSURLResponse *)response
+                       andData:(NSData *)responseData
+                      andQuery:(KIOQuery *)query
+                  andProjectID:(NSString *)projectID {
     // Check if call to the Query API failed
     if (!responseData) {
         KCLogError(@"responseData was nil for some reason.  That's not great.");
@@ -163,7 +163,7 @@
         return;
     }
 
-    NSInteger responseCode = [((NSHTTPURLResponse*)response) statusCode];
+    NSInteger responseCode = [((NSHTTPURLResponse *)response) statusCode];
 
     // if the query failed because of a client error, let's add it to the database
     if ([HTTPCodes httpCodeType:(responseCode)] == HTTPCode4XXClientError && query != nil) {
@@ -183,10 +183,10 @@
 
 
 
-- (void)runMultiAnalysisWithQueries:(NSArray*)keenQueries
-                      withProjectID:(NSString*)projectID
-                        withReadKey:(NSString*)readKey
-                  completionHandler:(void (^)(NSData* data, NSURLResponse* response, NSError* error))completionHandler {
+- (void)runMultiAnalysisWithQueries:(NSArray *)keenQueries
+                      withProjectID:(NSString *)projectID
+                        withReadKey:(NSString *)readKey
+                  completionHandler:(void (^)(NSData *data, NSURLResponse *response, NSError *error))completionHandler {
     NSString *urlString = [NSString stringWithFormat:@"%@/%@/projects/%@/queries/%@",
                            kKeenServerAddress, kKeenApiVersion, projectID, @"multi_analysis"];
     KCLogVerbose(@"Sending request to: %@", urlString);
@@ -197,46 +197,43 @@
     }
 
     //convert the resulting dictionary to data and set it as HTTPBody
-    NSError *dictionarySerializationError = nil;
-
+    NSError *dictionarySerializationError;
     NSData *multiAnalysisData = [NSJSONSerialization dataWithJSONObject:multiAnalysisDictionary options:0 error:&dictionarySerializationError];
-
-    if(dictionarySerializationError != nil) {
+    if (dictionarySerializationError != nil) {
         KCLogError(@"error with dictionary serialization");
         return;
     }
 
-    NSMutableURLRequest* request = [self createRequestWithUrl:urlString
+    NSMutableURLRequest *request = [self createRequestWithUrl:urlString
                                                       andBody:multiAnalysisData
                                                        andKey:readKey];
 
-    [self executeRequest:request
-       completionHandler:completionHandler];
+    [self executeRequest:request completionHandler:completionHandler];
 }
 
 
 # pragma mark Helper Methods
 
-- (NSDictionary*)prepareQueriesDictionaryForMultiAnalysis:(NSArray*)keenQueries {
+- (NSDictionary *)prepareQueriesDictionaryForMultiAnalysis:(NSArray *)keenQueries {
     NSMutableDictionary* multiAnalysisDictionary = [@{@"event_collection": [NSNull null],
                                                       @"filters": [NSNull null],
                                                       @"timeframe": [NSNull null],
                                                       @"timezone": [NSNull null],
                                                       @"group_by": [NSNull null],
                                                       @"interval": [NSNull null]} mutableCopy];
-    NSMutableDictionary* queriesDictionary = [[NSMutableDictionary alloc] init];
+    NSMutableDictionary *queriesDictionary = [NSMutableDictionary dictionary];
     for (int i = 0; i < keenQueries.count; i++) {
         if (![keenQueries[i] isKindOfClass:[KIOQuery class]]) {
             KCLogError(@"keenQueries array contain objects that are not of class KIOQuery");
             return nil;
         }
 
-        KIOQuery* query = keenQueries[i];
-        NSMutableDictionary* queryMutablePropertiesDictionary = [[query propertiesDictionary] mutableCopy];
+        KIOQuery *query = keenQueries[i];
+        NSMutableDictionary *queryMutablePropertiesDictionary = [[query propertiesDictionary] mutableCopy];
 
         //check that Keen queries have the same parameters
-        for (NSString* key in [multiAnalysisDictionary allKeys]) {
-            NSObject* queryProperty = [[query propertiesDictionary] objectForKey:key];
+        for (NSString *key in [multiAnalysisDictionary allKeys]) {
+            NSObject *queryProperty = [[query propertiesDictionary] objectForKey:key];
             if (queryProperty != nil) {
                 if ([multiAnalysisDictionary objectForKey:key] == [NSNull null]) {
                     [multiAnalysisDictionary setObject:queryProperty forKey:key];

--- a/KeenClient/KIOQuery.h
+++ b/KeenClient/KIOQuery.h
@@ -10,14 +10,12 @@
 
 @interface KIOQuery : NSObject
 
-@property (nonatomic, strong) NSString *queryType;
-@property (nonatomic, strong) NSString *queryName;
-@property (nonatomic, strong) NSDictionary *propertiesDictionary;
+@property (nonatomic) NSString *queryType;
+@property (nonatomic) NSString *queryName;
+@property (nonatomic) NSDictionary *propertiesDictionary;
 
 - (id)initWithQuery:(NSString *)queryType andPropertiesDictionary:(NSDictionary *)propertiesDictionary;
 - (id)initWithQuery:(NSString *)queryType andQueryName:(NSString *)queryName andPropertiesDictionary:(NSDictionary *)propertiesDictionary;
-
-+ (BOOL)validateQueryType:(NSString *)queryType;
 
 - (NSData *)convertQueryToData;
 

--- a/KeenClient/KIOQuery.m
+++ b/KeenClient/KIOQuery.m
@@ -15,7 +15,7 @@
         return nil;
     }
     
-    self = [self init];
+    self = [super init];
     
     if (self) {
         self.queryType = queryType;
@@ -30,7 +30,7 @@
         return nil;
     }
     
-    self = [self init];
+    self = [super init];
     
     if (self) {
         self.queryType = queryType;

--- a/KeenClient/KIOQuery.m
+++ b/KeenClient/KIOQuery.m
@@ -11,7 +11,7 @@
 @implementation KIOQuery
 
 - (id)initWithQuery:(NSString *)queryType andPropertiesDictionary:(NSDictionary *)propertiesDictionary {
-    if (![KIOQuery validateQueryType:queryType]) {
+    if (queryType == nil || queryType.length <= 0) {
         return nil;
     }
     
@@ -26,7 +26,7 @@
 }
 
 - (id)initWithQuery:(NSString *)queryType andQueryName:(NSString *)queryName andPropertiesDictionary:(NSDictionary *)propertiesDictionary {
-    if (![KIOQuery validateQueryType:queryType]) {
+    if (queryType == nil || queryType.length <= 0) {
         return nil;
     }
     
@@ -41,17 +41,8 @@
     return self;
 }
 
-+ (BOOL)validateQueryType:(NSString *)queryType {
-    // TODO: Validate query type on client side?
-    if (!queryType || [queryType length] == 0) {
-        return NO;
-    }
-    return YES;
-}
-
 - (NSData *)convertQueryToData {
-    NSError *error = nil;
-    
+    NSError *error;
     NSData *data = [NSJSONSerialization dataWithJSONObject:self.propertiesDictionary options:0 error:&error];
     
     return data;

--- a/KeenClient/KIOUploader.h
+++ b/KeenClient/KIOUploader.h
@@ -19,6 +19,7 @@
 + (instancetype)sharedInstance;
 
 // Initialize an instance of the object
+- (instancetype)init NS_UNAVAILABLE;
 - (instancetype)initWithNetwork:(KIONetwork *)network
                        andStore:(KIODBStore *)store;
 

--- a/KeenClient/KIOUploader.h
+++ b/KeenClient/KIOUploader.h
@@ -19,12 +19,12 @@
 + (instancetype)sharedInstance;
 
 // Initialize an instance of the object
-- (instancetype)initWithNetwork:(KIONetwork*)network
-                       andStore:(KIODBStore*)store;
+- (instancetype)initWithNetwork:(KIONetwork *)network
+                       andStore:(KIODBStore *)store;
 
 // Upload events in the store for a given project
-- (void)uploadEventsForProjectID:(NSString*)projectID
-                    withWriteKey:(NSString*)writeKey
+- (void)uploadEventsForProjectID:(NSString *)projectID
+                    withWriteKey:(NSString *)writeKey
                withFinishedBlock:(void (^)())block;
 
 @end

--- a/KeenClient/KIOUploader.m
+++ b/KeenClient/KIOUploader.m
@@ -47,7 +47,7 @@
 
 
 + (instancetype)sharedInstance {
-    static KIOUploader *s_sharedInstance = nil;
+    static KIOUploader *s_sharedInstance;
 
     // This black magic ensures this block
     // is dispatched only once over the lifetime
@@ -65,15 +65,10 @@
     return s_sharedInstance;
 }
 
-- (instancetype)init {
-    [NSException raise:@"InvalidOperation" format:@"init not implemented."];
-    return nil;
-}
-
 - (instancetype)initWithNetwork:(KIONetwork *)network
                        andStore:(KIODBStore *)store {
     self = [super init];
-    if (self){
+    if (self) {
         // Create a serialized queue to handle all upload operations
         self.uploadQueue = dispatch_queue_create("io.keen.uploader", DISPATCH_QUEUE_SERIAL);
 
@@ -120,9 +115,9 @@
             // add it to the array of events
             [eventsArray addObject:eventDict];
             if ([eventIDDict objectForKey:coll] == nil) {
-                [eventIDDict setObject: [NSMutableArray array] forKey: coll];
+                [eventIDDict setObject: [NSMutableArray array] forKey:coll];
             }
-            [[eventIDDict objectForKey:coll] addObject: eid];
+            [[eventIDDict objectForKey:coll] addObject:eid];
         }
 
         // add the array of events to the request
@@ -170,8 +165,8 @@
         [KIOFileStore maybeMigrateDataFromFileStore:projectID];
 
         // get data for the API request we'll make
-        NSData *data = nil;
-        NSMutableDictionary *eventIDs = nil;
+        NSData *data;
+        NSMutableDictionary *eventIDs;
         [self prepareJSONData:&data andEventIDs:&eventIDs forProjectID:projectID];
 
         if ([data length] == 0) {
@@ -274,7 +269,7 @@
 
             // delete the file if we need to
             if (deleteFile) {
-                [self.store deleteEvent: eid];
+                [self.store deleteEvent:eid];
                 KCLogVerbose(@"Successfully deleted event: %@", eid);
             }
             count++;

--- a/KeenClient/KIOUploader.m
+++ b/KeenClient/KIOUploader.m
@@ -36,9 +36,9 @@
 // A dispatch queue used for uploads.
 @property (nonatomic) dispatch_queue_t uploadQueue;
 
-@property (nonatomic) KIODBStore* store;
+@property (nonatomic) KIODBStore *store;
 
-@property (nonatomic) KIONetwork* network;
+@property (nonatomic) KIONetwork *network;
 
 @end
 
@@ -47,7 +47,7 @@
 
 
 + (instancetype)sharedInstance {
-    static KIOUploader* s_sharedInstance = nil;
+    static KIOUploader *s_sharedInstance = nil;
 
     // This black magic ensures this block
     // is dispatched only once over the lifetime
@@ -70,10 +70,10 @@
     return nil;
 }
 
-- (instancetype)initWithNetwork:(KIONetwork*)network
-                       andStore:(KIODBStore*)store {
+- (instancetype)initWithNetwork:(KIONetwork *)network
+                       andStore:(KIODBStore *)store {
     self = [super init];
-    if (nil != self){
+    if (self){
         // Create a serialized queue to handle all upload operations
         self.uploadQueue = dispatch_queue_create("io.keen.uploader", DISPATCH_QUEUE_SERIAL);
 
@@ -87,9 +87,9 @@
 }
 
 
-- (void)prepareJSONData:(NSData**)jsonData
-            andEventIDs:(NSMutableDictionary**)eventIDs
-           forProjectID:(NSString*)projectID {
+- (void)prepareJSONData:(NSData **)jsonData
+            andEventIDs:(NSMutableDictionary **)eventIDs
+           forProjectID:(NSString *)projectID {
     // set up the request dictionary we'll send out.
     NSMutableDictionary *requestDict = [NSMutableDictionary dictionary];
 
@@ -100,12 +100,12 @@
     NSMutableDictionary *events = [self.store getEventsWithMaxAttempts:self.maxEventUploadAttempts
                                                           andProjectID:projectID];
 
-    NSError *error = nil;
+    NSError *error;
     for (NSString *coll in events) {
         NSDictionary *collEvents = [events objectForKey:coll];
 
         // create a separate array for event data so our dictionary serializes properly
-        NSMutableArray *eventsArray = [[NSMutableArray alloc] init];
+        NSMutableArray *eventsArray = [NSMutableArray array];
 
         for (NSNumber *eid in collEvents) {
             NSData *ev = [collEvents objectForKey:eid];
@@ -156,8 +156,8 @@
     return [hostReachability KIOcurrentReachabilityStatus] != NotReachable;
 }
 
-- (void)uploadEventsForProjectID:(NSString*)projectID
-                    withWriteKey:(NSString*)writeKey
+- (void)uploadEventsForProjectID:(NSString *)projectID
+                    withWriteKey:(NSString *)writeKey
                withFinishedBlock:(void (^)())block {
     dispatch_async(self.uploadQueue, ^{
         if (![self isNetworkConnected]) {
@@ -221,63 +221,64 @@
         return;
     }
     NSInteger responseCode = [((NSHTTPURLResponse *)response) statusCode];
-    // if the request succeeded, dig into the response to figure out which events succeeded and which failed
-    if ([HTTPCodes httpCodeType:(responseCode)] == HTTPCode2XXSuccess) {
-        // deserialize the response
-        NSError *error = nil;
-        NSDictionary *responseDict = [NSJSONSerialization JSONObjectWithData:responseData
-                                                                     options:0
-                                                                       error:&error];
-        if (error) {
-            NSString *responseString = [[NSString alloc] initWithData:responseData encoding:NSUTF8StringEncoding];
-            KCLogError(@"An error occurred when deserializing HTTP response JSON into dictionary.\nError: %@\nResponse: %@",
-                  [error localizedDescription],
-                  responseString);
-            return;
-        }
-        // now iterate through the keys of the response, which represent collection names
-        NSArray *collectionNames = [responseDict allKeys];
-        for (NSString *collectionName in collectionNames) {
-            // grab the results for this collection
-            NSArray *results = [responseDict objectForKey:collectionName];
-            // go through and delete any successes and failures because of user error
-            // (making sure to keep any failures due to server error)
-            NSUInteger count = 0;
-            for (NSDictionary *result in results) {
-                BOOL deleteFile = YES;
-                BOOL success = [[result objectForKey:kKeenSuccessParam] boolValue];
-                if (!success) {
-                    // grab error code and description
-                    NSDictionary *errorDict = [result objectForKey:kKeenErrorParam];
-                    NSString *errorCode = [errorDict objectForKey:kKeenNameParam];
-                    if ([errorCode isEqualToString:kKeenInvalidCollectionNameError] ||
-                        [errorCode isEqualToString:kKeenInvalidPropertyNameError] ||
-                        [errorCode isEqualToString:kKeenInvalidPropertyValueError]) {
-                        KCLogError(@"An invalid event was found.  Deleting it.  Error: %@",
-                                   [errorDict objectForKey:kKeenDescriptionParam]);
-                        deleteFile = YES;
-                    } else {
-                        KCLogError(@"The event could not be inserted for some reason.  Error name and description: %@, %@",
-                                   errorCode, [errorDict objectForKey:kKeenDescriptionParam]);
-                        deleteFile = NO;
-                    }
-                }
-
-                NSNumber *eid = [[eventIds objectForKey:collectionName] objectAtIndex:count];
-
-                // delete the file if we need to
-                if (deleteFile) {
-                    [self.store deleteEvent: eid];
-                    KCLogVerbose(@"Successfully deleted event: %@", eid);
-                }
-                count++;
-            }
-        }
-    } else {
+    if ([HTTPCodes httpCodeType:(responseCode)] != HTTPCode2XXSuccess) {
         // response code was NOT 2xx, which means something else happened. log this.
         KCLogError(@"Response code was NOT 2xx. It was: %ld", (long)responseCode);
         NSString *responseString = [[NSString alloc] initWithData:responseData encoding:NSUTF8StringEncoding];
         KCLogError(@"Response body was: %@", responseString);
+        return;
+    }
+
+    // if the request succeeded, dig into the response to figure out which events succeeded and which failed
+    // deserialize the response
+    NSError *error;
+    NSDictionary *responseDict = [NSJSONSerialization JSONObjectWithData:responseData
+                                                                 options:0
+                                                                   error:&error];
+    if (error) {
+        NSString *responseString = [[NSString alloc] initWithData:responseData encoding:NSUTF8StringEncoding];
+        KCLogError(@"An error occurred when deserializing HTTP response JSON into dictionary.\nError: %@\nResponse: %@",
+                   [error localizedDescription],
+                   responseString);
+        return;
+    }
+    // now iterate through the keys of the response, which represent collection names
+    NSArray *collectionNames = [responseDict allKeys];
+    for (NSString *collectionName in collectionNames) {
+        // grab the results for this collection
+        NSArray *results = [responseDict objectForKey:collectionName];
+        // go through and delete any successes and failures because of user error
+        // (making sure to keep any failures due to server error)
+        NSUInteger count = 0;
+        for (NSDictionary *result in results) {
+            BOOL deleteFile = YES;
+            BOOL success = [[result objectForKey:kKeenSuccessParam] boolValue];
+            if (!success) {
+                // grab error code and description
+                NSDictionary *errorDict = [result objectForKey:kKeenErrorParam];
+                NSString *errorCode = [errorDict objectForKey:kKeenNameParam];
+                if ([errorCode isEqualToString:kKeenInvalidCollectionNameError] ||
+                    [errorCode isEqualToString:kKeenInvalidPropertyNameError] ||
+                    [errorCode isEqualToString:kKeenInvalidPropertyValueError]) {
+                    KCLogError(@"An invalid event was found.  Deleting it.  Error: %@",
+                               [errorDict objectForKey:kKeenDescriptionParam]);
+                    deleteFile = YES;
+                } else {
+                    KCLogError(@"The event could not be inserted for some reason.  Error name and description: %@, %@",
+                               errorCode, [errorDict objectForKey:kKeenDescriptionParam]);
+                    deleteFile = NO;
+                }
+            }
+
+            NSNumber *eid = [[eventIds objectForKey:collectionName] objectAtIndex:count];
+
+            // delete the file if we need to
+            if (deleteFile) {
+                [self.store deleteEvent: eid];
+                KCLogVerbose(@"Successfully deleted event: %@", eid);
+            }
+            count++;
+        }
     }
 }
 

--- a/KeenClient/KIOUtil.h
+++ b/KeenClient/KIOUtil.h
@@ -11,14 +11,8 @@
 @interface KIOUtil : NSObject
 
 // Serialize a mutable dictionary to JSON
-+ (NSData*)serializeEventToJSON:(NSMutableDictionary*)event
-                           error:(NSError**)error;
-
-// Enumerate a dictionary and replace immutable objects with mutable copies
-+ (NSMutableDictionary*)makeDictionaryMutable:(NSDictionary*)dict;
-
-// Create a mutable copy of an array
-+ (NSMutableArray*)makeArrayMutable:(NSArray*)array;
++ (NSData *)serializeEventToJSON:(NSMutableDictionary *)event
+                           error:(NSError **)error;
 
 // Enumerate an object and massage it into a format that can be converted to JSON
 + (id)handleInvalidJSONInObject:(id)value;
@@ -28,12 +22,12 @@
 
  @return Always return NO.
  */
-+ (BOOL)handleError:(NSError**)error
-   withErrorMessage:(NSString*)errorMessage;
++ (BOOL)handleError:(NSError **)error
+   withErrorMessage:(NSString *)errorMessage;
 
-+ (BOOL)handleError:(NSError**)error
-   withErrorMessage:(NSString*)errorMessage
-    underlyingError:(NSError*)underlyingError;
++ (BOOL)handleError:(NSError **)error
+   withErrorMessage:(NSString *)errorMessage
+    underlyingError:(NSError *)underlyingError;
 
 /**
  Converts an NSDate* instance into a correctly formatted ISO-8601 compatible string.

--- a/KeenClient/KIOUtil.m
+++ b/KeenClient/KIOUtil.m
@@ -52,7 +52,7 @@
 
         NSMutableDictionary *dict = [NSMutableDictionary dictionary];
         NSString *isoDate = [self convertDate:keenProperties.timestamp];
-        if (isoDate != nil) {
+        if (isoDate) {
             [dict setObject:isoDate forKey:@"timestamp"];
         }
 

--- a/KeenClient/KIOUtil.m
+++ b/KeenClient/KIOUtil.m
@@ -13,7 +13,7 @@
 
 @implementation KIOUtil
 
-+ (NSData *)serializeEventToJSON:(NSMutableDictionary *)event error:(NSError**) error {
++ (NSData *)serializeEventToJSON:(NSMutableDictionary *)event error:(NSError **) error {
     id fixed = [self handleInvalidJSONInObject:event];
 
     if (![NSJSONSerialization isValidJSONObject:fixed]) {
@@ -23,21 +23,13 @@
     return [NSJSONSerialization dataWithJSONObject:fixed options:0 error:error];
 }
 
-+ (NSMutableDictionary *)makeDictionaryMutable:(NSDictionary *)dict {
-    return [dict mutableCopy];
-}
-
-+ (NSMutableArray *)makeArrayMutable:(NSArray *)array {
-    return [array mutableCopy];
-}
-
 + (id)handleInvalidJSONInObject:(id)value {
     if (!value) {
         return value;
     }
 
     if ([value isKindOfClass:[NSDictionary class]]) {
-        NSMutableDictionary *mutDict = [self makeDictionaryMutable:value];
+        NSMutableDictionary *mutDict = [value mutableCopy];
         NSArray *keys = [mutDict allKeys];
         for (NSString *dictKey in keys) {
             id newValue = [self handleInvalidJSONInObject:[mutDict objectForKey:dictKey]];
@@ -46,7 +38,7 @@
         return mutDict;
     } else if ([value isKindOfClass:[NSArray class]]) {
         // make sure the array is mutable and then recurse for every element
-        NSMutableArray *mutArr = [self makeArrayMutable:value];
+        NSMutableArray *mutArr = [value mutableCopy];
         for (NSUInteger i=0; i<[mutArr count]; i++) {
             id arrVal = [mutArr objectAtIndex:i];
             arrVal = [self handleInvalidJSONInObject:arrVal];
@@ -58,14 +50,14 @@
     } else if ([value isKindOfClass:[KeenProperties class]]) {
         KeenProperties *keenProperties = value;
 
-        NSMutableDictionary *dict = [[NSMutableDictionary alloc] init];
+        NSMutableDictionary *dict = [NSMutableDictionary dictionary];
         NSString *isoDate = [self convertDate:keenProperties.timestamp];
         if (isoDate != nil) {
             [dict setObject:isoDate forKey:@"timestamp"];
         }
 
         CLLocation *location = keenProperties.location;
-        if (location != nil) {
+        if (location) {
             NSNumber *longitude = [NSNumber numberWithDouble:location.coordinate.longitude];
             NSNumber *latitude = [NSNumber numberWithDouble:location.coordinate.latitude];
             NSArray *coordinatesArray = [NSArray arrayWithObjects:longitude, latitude, nil];
@@ -79,17 +71,14 @@
     }
 }
 
-+ (BOOL)handleError:(NSError**)error
-   withErrorMessage:(NSString*)errorMessage {
-    return [self handleError:error
-            withErrorMessage:errorMessage
-             underlyingError:nil];
++ (BOOL)handleError:(NSError**)error withErrorMessage:(NSString*)errorMessage {
+    return [self handleError:error withErrorMessage:errorMessage underlyingError:nil];
 }
 
 + (BOOL)handleError:(NSError**)error
    withErrorMessage:(NSString*)errorMessage
     underlyingError:(NSError *)underlyingError {
-    if (error != NULL) {
+    if (error) {
         const id<NSCopying> keys[] = {NSLocalizedDescriptionKey, NSUnderlyingErrorKey};
         const id objects[] = {errorMessage, underlyingError};
         NSUInteger count = underlyingError ? 2 : 1;
@@ -104,7 +93,7 @@
 # pragma mark - NSDate => NSString
 
 + (id)convertDate:(id)date {
-    NSDateFormatter *dateFormatter = [[NSDateFormatter alloc] init];
+    NSDateFormatter *dateFormatter = [NSDateFormatter new];
     NSLocale *enUSPOSIXLocale = [NSLocale localeWithLocaleIdentifier:@"en_US_POSIX"];
     [dateFormatter setLocale:enUSPOSIXLocale];
     [dateFormatter setDateFormat:@"yyyy-MM-dd'T'HH:mm:ssZZZZZ"];

--- a/KeenClient/KeenClient.h
+++ b/KeenClient/KeenClient.h
@@ -197,8 +197,8 @@ typedef NSDictionary* (^KeenGlobalPropertiesBlock)(NSString *eventCollection);
 
  @return An instance of KIOEventStore.
  */
-+ (KIODBStore*)getDBStore DEPRECATED_MSG_ATTRIBUTE("Class method getDBStore is deprecated. User instance method instead.");
-- (KIODBStore*)getDBStore;
++ (KIODBStore *)getDBStore DEPRECATED_MSG_ATTRIBUTE("Class method getDBStore is deprecated. User instance method instead.");
+- (KIODBStore *)getDBStore;
 
 /**
  Call this if your code needs to use more than one Keen project.  By convention, if you

--- a/KeenClient/KeenClient.m
+++ b/KeenClient/KeenClient.m
@@ -311,11 +311,6 @@ static BOOL geoLocationRequestEnabled = YES;
         return nil;
     }
 
-    // If the keys are already set, return the existing instance, don't overwrite the keys
-    if (self.sharedClient.projectID || self.sharedClient.writeKey || self.sharedClient.readKey) {
-        return self.sharedClient;
-    }
-
     self.sharedClient.projectID = projectID;
     self.sharedClient.writeKey = writeKey;
     self.sharedClient.readKey = readKey;

--- a/KeenClient/KeenClient.m
+++ b/KeenClient/KeenClient.m
@@ -366,7 +366,8 @@ static BOOL geoLocationRequestEnabled = YES;
         }
 #if __IPHONE_OS_VERSION_MAX_ALLOWED >= 80000
         // Else, try and request permission for that.
-        else if (geoLocationRequestEnabled) {
+        else if (geoLocationRequestEnabled &&
+                 [self.locationManager respondsToSelector:@selector(requestAlwaysAuthorization)]) {
             // allow explicit control over the type of authorization
             if (authorizedGeoLocationAlways) {
                 [self.locationManager requestAlwaysAuthorization];

--- a/KeenClient/KeenClient.m
+++ b/KeenClient/KeenClient.m
@@ -355,50 +355,43 @@ static BOOL geoLocationRequestEnabled = YES;
 # pragma mark - Geo stuff
 
 - (void)refreshCurrentLocation {
-    // only do this if geo is enabled
-    if (geoLocationEnabled == YES) {
-        KCLogInfo(@"Geo Location is enabled.");
-        // set up the location manager
-        if (self.locationManager == nil && [CLLocationManager locationServicesEnabled]) {
-            self.locationManager = [[CLLocationManager alloc] init];
-            self.locationManager.delegate = self;
-        }
-
-        // check for iOS 8 and provide appropriate authorization for location services
-
-        if(self.locationManager != nil)
-        {
-            // If location services are already authorized, then just start monitoring.
-            CLAuthorizationStatus clAuthStatus = [CLLocationManager authorizationStatus];
-            if ([KeenClient isLocationAuthorized:clAuthStatus]) {
-                [self startMonitoringLocation];
-            }
-#if __IPHONE_OS_VERSION_MAX_ALLOWED >= 80000
-            // Else, try and request permission for that.
-            else if (geoLocationRequestEnabled &&
-                     [self.locationManager respondsToSelector:@selector(requestAlwaysAuthorization)]) {
-                // allow explicit control over the type of authorization
-                if(authorizedGeoLocationAlways) {
-                    [self.locationManager requestAlwaysAuthorization];
-                }
-                else if(authorizedGeoLocationWhenInUse) {
-                    [self.locationManager requestWhenInUseAuthorization];
-                }
-                else if(!authorizedGeoLocationAlways && !authorizedGeoLocationWhenInUse) {
-                    // default to when in use because it is the least invasive authorization
-                    [self.locationManager requestWhenInUseAuthorization];
-                }
-            }
-#endif
-        }
-
-    } else {
+    if (geoLocationEnabled == NO) {
         KCLogInfo(@"Geo Location is disabled.");
+        return;
+    }
+
+    KCLogInfo(@"Geo Location is enabled.");
+    // set up the location manager
+    if (self.locationManager == nil && [CLLocationManager locationServicesEnabled]) {
+        self.locationManager = [[CLLocationManager alloc] init];
+        self.locationManager.delegate = self;
+    }
+
+    // Provide appropriate authorization for location services
+
+    if (self.locationManager != nil) {
+        // If location services are already authorized, then just start monitoring.
+        CLAuthorizationStatus clAuthStatus = [CLLocationManager authorizationStatus];
+        if ([KeenClient isLocationAuthorized:clAuthStatus]) {
+            [self startMonitoringLocation];
+        }
+        // Else, try and request permission for that.
+        else if (geoLocationRequestEnabled) {
+            // allow explicit control over the type of authorization
+            if (authorizedGeoLocationAlways) {
+                [self.locationManager requestAlwaysAuthorization];
+            } else if (authorizedGeoLocationWhenInUse) {
+                [self.locationManager requestWhenInUseAuthorization];
+            } else if (!authorizedGeoLocationAlways && !authorizedGeoLocationWhenInUse) {
+                // default to when in use because it is the least invasive authorization
+                [self.locationManager requestWhenInUseAuthorization];
+            }
+        }
     }
 }
 
--(void)startMonitoringLocation {
-    if(self.locationManager) {
+- (void)startMonitoringLocation {
+    if (self.locationManager) {
         [self.locationManager startUpdatingLocation];
         KCLogInfo(@"Started location manager.");
     }

--- a/KeenClient/KeenClient.m
+++ b/KeenClient/KeenClient.m
@@ -391,10 +391,8 @@ static BOOL geoLocationRequestEnabled = YES;
 }
 
 - (void)startMonitoringLocation {
-    if (self.locationManager) {
-        [self.locationManager startUpdatingLocation];
-        KCLogInfo(@"Started location manager.");
-    }
+    [self.locationManager startUpdatingLocation];
+    KCLogInfo(@"Started location manager.");
 }
 
 + (BOOL)isLocationAuthorized:(CLAuthorizationStatus)status {

--- a/KeenClient/KeenClient.m
+++ b/KeenClient/KeenClient.m
@@ -158,7 +158,7 @@ static BOOL geoLocationRequestEnabled = YES;
     [[KeenLogger sharedLogger] setLogLevel:level];
 }
 
-+ (void)logMessageWithLevel:(KeenLogLevel)level andMessage:(NSString*)message {
++ (void)logMessageWithLevel:(KeenLogLevel)level andMessage:(NSString *)message {
     [[KeenLogger sharedLogger] logMessageWithLevel:level andMessage:message];
 }
 
@@ -352,7 +352,7 @@ static BOOL geoLocationRequestEnabled = YES;
     KCLogInfo(@"Geo Location is enabled.");
     // set up the location manager
     if (self.locationManager == nil && [CLLocationManager locationServicesEnabled]) {
-        self.locationManager = [[CLLocationManager alloc] init];
+        self.locationManager = [CLLocationManager new];
         self.locationManager.delegate = self;
     }
 
@@ -430,7 +430,7 @@ static BOOL geoLocationRequestEnabled = YES;
 # pragma mark - Add events
 
 - (BOOL)validateEventCollection:(NSString *)eventCollection error:(NSError **)anError {
-    NSString *errorMessage = nil;
+    NSString *errorMessage;
 
     if ([eventCollection hasPrefix:@"$"]) {
         errorMessage = @"An event collection name cannot start with the dollar sign ($) character.";

--- a/KeenClient/KeenClient.m
+++ b/KeenClient/KeenClient.m
@@ -364,6 +364,7 @@ static BOOL geoLocationRequestEnabled = YES;
         if ([KeenClient isLocationAuthorized:clAuthStatus]) {
             [self startMonitoringLocation];
         }
+#if __IPHONE_OS_VERSION_MAX_ALLOWED >= 80000
         // Else, try and request permission for that.
         else if (geoLocationRequestEnabled) {
             // allow explicit control over the type of authorization
@@ -376,6 +377,7 @@ static BOOL geoLocationRequestEnabled = YES;
                 [self.locationManager requestWhenInUseAuthorization];
             }
         }
+#endif
     }
 }
 

--- a/KeenClient/KeenClient.m
+++ b/KeenClient/KeenClient.m
@@ -74,17 +74,6 @@ static BOOL geoLocationRequestEnabled = YES;
 
 @implementation KeenClient
 
-@synthesize projectID=_projectID;
-@synthesize writeKey=_writeKey;
-@synthesize readKey=_readKey;
-@synthesize locationManager=_locationManager;
-@synthesize currentLocation=_currentLocation;
-@synthesize numTimesTimestampUsed=_numTimesTimestampUsed;
-@synthesize isRunningTests=_isRunningTests;
-@synthesize globalPropertiesDictionary=_globalPropertiesDictionary;
-@synthesize globalPropertiesBlock=_globalPropertiesBlock;
-@synthesize queryQueue;
-
 /**
  The maximum number of times to try POSTing an event before purging it from the DB.
  */

--- a/KeenClient/KeenClient.m
+++ b/KeenClient/KeenClient.m
@@ -70,20 +70,6 @@ static BOOL geoLocationRequestEnabled = YES;
  */
 - (id)init;
 
-/**
- Validates that the given project ID is valid.
- @param projectID The Keen project ID.
- @returns YES if project id is valid, NO otherwise.
- */
-+ (BOOL)validateProjectID:(NSString *)projectID;
-
-/**
- Validates that the given key is valid.
- @param key The key to check.
- @returns YES if key is valid, NO otherwise.
- */
-+ (BOOL)validateKey:(NSString *)key;
-
 @end
 
 @implementation KeenClient
@@ -240,19 +226,6 @@ static BOOL geoLocationRequestEnabled = YES;
     return self.sharedClient.store;
 }
 
-+ (BOOL)validateProjectID:(NSString *)projectID {
-    // validate that project ID is acceptable
-    if (!projectID || [projectID length] == 0) {
-        return NO;
-    }
-    return YES;
-}
-
-+ (BOOL)validateKey:(NSString *)key {
-    // for now just use the same rules as project ID
-    return [KeenClient validateProjectID:key];
-}
-
 - (instancetype)initWithNetwork:(KIONetwork*)network
                        andStore:(KIODBStore*)store
                     andUploader:(KIOUploader*)uploader {
@@ -278,31 +251,29 @@ static BOOL geoLocationRequestEnabled = YES;
 - (id)initWithProjectID:(NSString *)projectID
             andWriteKey:(NSString *)writeKey
              andReadKey:(NSString *)readKey
-             andNetwork:(KIONetwork*)network
-               andStore:(KIODBStore*)store
-            andUploader:(KIOUploader*)uploader {
-    // Validate key parameters
-    if (![KeenClient validateProjectID:projectID]) {
-        KCLogError(@"Invalid projectID: %@", projectID);
+             andNetwork:(KIONetwork *)network
+               andStore:(KIODBStore *)store
+            andUploader:(KIOUploader *)uploader {
+    if (projectID == nil || projectID.length <= 0) {
+        KCLogError(@"You must provide a projectID.");
         return nil;
     }
 
-    if (nil != writeKey && // only validate a non-nil value
-        ![KeenClient validateKey:writeKey]) {
-        KCLogError(@"Invalid writeKey: %@", writeKey);
+    if (writeKey && writeKey.length <= 0) {
+        KCLogError(@"Your writeKey cannot be an empty string.");
         return nil;
     }
 
-    if (nil != readKey && // only validate a non-nil value
-        ![KeenClient validateKey:readKey]) {
-        KCLogError(@"Invalid readKey: %@", readKey);
+    if (readKey && readKey.length <= 0) {
+        KCLogError(@"Your readKey cannot be an empty string.");
         return nil;
     }
 
     self = [self initWithNetwork:network
                         andStore:store
                      andUploader:uploader];
-    if (nil != self) {
+
+    if (self) {
         self.projectID = projectID;
         self.writeKey = writeKey;
         self.readKey = readKey;
@@ -336,20 +307,18 @@ static BOOL geoLocationRequestEnabled = YES;
                               andWriteKey:(NSString *)writeKey
                                andReadKey:(NSString *)readKey {
     // Validate key parameters
-    if (![KeenClient validateProjectID:projectID]) {
-        KCLogError(@"Invalid projectID: %@", projectID);
+    if (projectID == nil || projectID.length <= 0) {
+        KCLogError(@"You must provide a projectID.");
         return nil;
     }
 
-    if (nil != writeKey && // only validate a non-nil value
-        ![KeenClient validateKey:writeKey]) {
-        KCLogError(@"Invalid writeKey: %@", writeKey);
+    if (writeKey && writeKey.length <= 0) {
+        KCLogError(@"Your writeKey cannot be an empty string.");
         return nil;
     }
 
-    if (nil != readKey && // only validate a non-nil value
-        ![KeenClient validateKey:readKey]) {
-        KCLogError(@"Invalid readKey: %@", readKey);
+    if (readKey && readKey.length <= 0) {
+        KCLogError(@"Your readKey cannot be an empty string.");
         return nil;
     }
 
@@ -548,7 +517,7 @@ static BOOL geoLocationRequestEnabled = YES;
 
 - (BOOL)addEvent:(NSDictionary *)event withKeenProperties:(KeenProperties *)keenProperties toEventCollection:(NSString *)eventCollection error:(NSError **) anError {
     // make sure the write key has been set - can't do anything without that
-    if (![KeenClient validateKey:self.writeKey]) {
+    if (self.writeKey == nil || self.writeKey.length <= 0) {
         [NSException raise:@"KeenNoWriteKeyProvided" format:@"You tried to add an event without setting a write key, please set one!"];
     }
 

--- a/KeenClient/KeenClient.m
+++ b/KeenClient/KeenClient.m
@@ -335,7 +335,6 @@ static BOOL geoLocationRequestEnabled = YES;
 + (KeenClient *)sharedClientWithProjectID:(NSString *)projectID
                               andWriteKey:(NSString *)writeKey
                                andReadKey:(NSString *)readKey {
-
     // Validate key parameters
     if (![KeenClient validateProjectID:projectID]) {
         KCLogError(@"Invalid projectID: %@", projectID);
@@ -352,6 +351,11 @@ static BOOL geoLocationRequestEnabled = YES;
         ![KeenClient validateKey:readKey]) {
         KCLogError(@"Invalid readKey: %@", readKey);
         return nil;
+    }
+
+    // If the keys are already set, return the existing instance, don't overwrite the keys
+    if (self.sharedClient.projectID != nil || self.sharedClient.writeKey != nil || self.sharedClient.readKey != nil) {
+        return self.sharedClient;
     }
 
     self.sharedClient.projectID = projectID;

--- a/KeenClient/KeenLogSink.h
+++ b/KeenClient/KeenLogSink.h
@@ -25,7 +25,7 @@ typedef NS_ENUM(NSInteger, KeenLogLevel) {
 //
 @protocol KeenLogSink
 
-- (void)logMessageWithLevel:(KeenLogLevel)msgLevel andMessage:(NSString*)message;
+- (void)logMessageWithLevel:(KeenLogLevel)msgLevel andMessage:(NSString *)message;
 
 // Even after calling KeenClient removeLogSink, a sink will
 // receive messages that had already been queued before the call

--- a/KeenClient/KeenLogSinkNSLog.m
+++ b/KeenClient/KeenLogSinkNSLog.m
@@ -10,8 +10,8 @@
 
 @implementation KeenLogSinkNSLog
 
-- (void)logMessageWithLevel:(KeenLogLevel)msgLevel andMessage:(NSString*)message {
-    NSString* logPrefix;
+- (void)logMessageWithLevel:(KeenLogLevel)msgLevel andMessage:(NSString *)message {
+    NSString *logPrefix;
     switch (msgLevel) {
         case KeenLogLevelError:
             logPrefix = @"E:";

--- a/KeenClient/KeenLogger.h
+++ b/KeenClient/KeenLogger.h
@@ -15,7 +15,7 @@
 /**
  Get the shared logger instance.
  */
-+ (KeenLogger*)sharedLogger;
++ (KeenLogger *)sharedLogger;
 
 /**
  Call this to disable debug logging. It's disabled by default.

--- a/KeenClient/KeenLogger.m
+++ b/KeenClient/KeenLogger.m
@@ -98,7 +98,7 @@ KeenLogSinkNSLog* _logSinkNSLog;
     _isNSLogEnabled = isNSLogEnabled;
     dispatch_async(_loggerQueue, ^() {
         if (isNSLogEnabled) {
-            if (nil == _logSinkNSLog) {
+            if (_logSinkNSLog == nil) {
                 // Create the NSLog logger
                 _logSinkNSLog = [KeenLogSinkNSLog new];
             }
@@ -109,7 +109,7 @@ KeenLogSinkNSLog* _logSinkNSLog;
             }
         } else {
             // Remove the logger if it has been added
-            if (nil != _logSinkNSLog) {
+            if (_logSinkNSLog) {
                 if ([_logSinks containsObject:_logSinkNSLog]) {
                     [_logSinks removeObject:_logSinkNSLog];
                 }

--- a/KeenClient/KeenLogger.m
+++ b/KeenClient/KeenLogger.m
@@ -20,8 +20,8 @@ dispatch_queue_t _loggerQueue;
 KeenLogSinkNSLog* _logSinkNSLog;
 
 
-+ (KeenLogger*)sharedLogger {
-    static KeenLogger* s_logger;
++ (KeenLogger *)sharedLogger {
+    static KeenLogger *s_logger;
 
     // This black magic ensures this block
     // is dispatched only once over the lifetime
@@ -39,10 +39,10 @@ KeenLogSinkNSLog* _logSinkNSLog;
 }
 
 
-- (KeenLogger*)init {
+- (KeenLogger *)init {
     self = [super init];
 
-    if (nil != self) {
+    if (self) {
         // By default we won't enable logging.
         _areLogSinksEnabled = NO;
         _isLoggingEnabled = NO;
@@ -54,13 +54,13 @@ KeenLogSinkNSLog* _logSinkNSLog;
         // about concurrent access when adding and removing loggers
         // since those operations will be dispatched to this queue as well.
         _loggerQueue = dispatch_queue_create("io.keen.logger", DISPATCH_QUEUE_SERIAL);
-        if (NULL == _loggerQueue) {
+        if (_loggerQueue == NULL) {
             // Failed to allocate the queue
             self = nil;
         }
 
-        _logSinks = [[NSMutableArray alloc] init];
-        if (nil == _logSinks) {
+        _logSinks = [NSMutableArray array];
+        if (_logSinks == nil) {
             // Failed to allocate the array
             self = nil;
         }
@@ -100,7 +100,7 @@ KeenLogSinkNSLog* _logSinkNSLog;
         if (isNSLogEnabled) {
             if (nil == _logSinkNSLog) {
                 // Create the NSLog logger
-                _logSinkNSLog = [[KeenLogSinkNSLog alloc] init];
+                _logSinkNSLog = [KeenLogSinkNSLog new];
             }
 
             if (!([_logSinks containsObject:_logSinkNSLog])) {
@@ -153,7 +153,7 @@ KeenLogSinkNSLog* _logSinkNSLog;
 }
 
 
-- (void)logMessageWithLevel:(KeenLogLevel)msgLevel andMessage:(NSString*)message {
+- (void)logMessageWithLevel:(KeenLogLevel)msgLevel andMessage:(NSString *)message {
     if (YES == _isLoggingEnabled) { // Only bother to dispatch if logging is currently enabled
         dispatch_async(_loggerQueue, ^() {
             if (_areLogSinksEnabled &&

--- a/KeenClient/KeenProperties.h
+++ b/KeenClient/KeenProperties.h
@@ -19,12 +19,12 @@
  The time a particular event occured. The Keen Client will automatically generate this for you,
  but you can set it yourself if you'd like.
  */
-@property (nonatomic, strong) NSDate *timestamp;
+@property (nonatomic) NSDate *timestamp;
 
 /**
  The location where a particular event occured. The Keen Client will automatically generate this for you,
  but you can set it yourself if you'd like.
  */
-@property (nonatomic, strong) CLLocation *location;
+@property (nonatomic) CLLocation *location;
 
 @end

--- a/KeenClient/KeenProperties.m
+++ b/KeenClient/KeenProperties.m
@@ -10,9 +10,6 @@
 
 @implementation KeenProperties
 
-@synthesize timestamp=_timestamp;
-@synthesize location=_location;
-
 - (id)init {
     self = [super init];
 

--- a/KeenClient/KeenProperties.m
+++ b/KeenClient/KeenProperties.m
@@ -15,8 +15,10 @@
 
 - (id)init {
     self = [super init];
-    
-    self.timestamp = [NSDate date];
+
+    if (self) {
+        self.timestamp = [NSDate date];
+    }
     
     return self;
 }

--- a/KeenClientTests/KeenClientTests.m
+++ b/KeenClientTests/KeenClientTests.m
@@ -146,7 +146,7 @@ NSString* kDefaultReadKey = @"rk";
     XCTAssertTrue(client != client2, @"Another init should return a separate instance");
 }
 
-- (void)testSharedClientWithProjectID{
+- (void)testSharedClientWithProjectID {
     KeenClient *client = [KeenClient sharedClientWithProjectID:kDefaultProjectID andWriteKey:kDefaultWriteKey andReadKey:kDefaultReadKey];
     XCTAssertEqual(kDefaultProjectID, client.projectID, @"sharedClientWithProjectID with a non-nil project id should work.");
     XCTAssertEqualObjects(kDefaultWriteKey, client.writeKey, @"init with a valid project id should work");
@@ -154,8 +154,8 @@ NSString* kDefaultReadKey = @"rk";
 
     KeenClient *client2 = [KeenClient sharedClientWithProjectID:@"other" andWriteKey:@"wk2" andReadKey:@"rk2"];
     XCTAssertEqualObjects(client, client2, @"sharedClient should return the same instance");
-    XCTAssertEqualObjects(@"wk2", client2.writeKey, @"sharedClient with a valid project id should work");
-    XCTAssertEqualObjects(@"rk2", client2.readKey, @"sharedClient with a valid project id should work");
+    XCTAssertEqualObjects(kDefaultWriteKey, client2.writeKey, @"sharedClient should not change the writeKey after first init.");
+    XCTAssertEqualObjects(kDefaultReadKey, client2.readKey, @"sharedClient should not change the readKey after first init.");
 
     client = [KeenClient sharedClientWithProjectID:nil andWriteKey:kDefaultWriteKey andReadKey:kDefaultReadKey];
     XCTAssertNil(client, @"sharedClient with an invalid project id should return nil");

--- a/KeenClientTests/KeenClientTests.m
+++ b/KeenClientTests/KeenClientTests.m
@@ -146,7 +146,7 @@ NSString* kDefaultReadKey = @"rk";
     XCTAssertTrue(client != client2, @"Another init should return a separate instance");
 }
 
-- (void)testSharedClientWithProjectID {
+- (void)testSharedClientWithProjectID{
     KeenClient *client = [KeenClient sharedClientWithProjectID:kDefaultProjectID andWriteKey:kDefaultWriteKey andReadKey:kDefaultReadKey];
     XCTAssertEqual(kDefaultProjectID, client.projectID, @"sharedClientWithProjectID with a non-nil project id should work.");
     XCTAssertEqualObjects(kDefaultWriteKey, client.writeKey, @"init with a valid project id should work");
@@ -154,8 +154,8 @@ NSString* kDefaultReadKey = @"rk";
 
     KeenClient *client2 = [KeenClient sharedClientWithProjectID:@"other" andWriteKey:@"wk2" andReadKey:@"rk2"];
     XCTAssertEqualObjects(client, client2, @"sharedClient should return the same instance");
-    XCTAssertEqualObjects(kDefaultWriteKey, client2.writeKey, @"sharedClient should not change the writeKey after first init.");
-    XCTAssertEqualObjects(kDefaultReadKey, client2.readKey, @"sharedClient should not change the readKey after first init.");
+    XCTAssertEqualObjects(@"wk2", client2.writeKey, @"sharedClient with a valid project id should work");
+    XCTAssertEqualObjects(@"rk2", client2.readKey, @"sharedClient with a valid project id should work");
 
     client = [KeenClient sharedClientWithProjectID:nil andWriteKey:kDefaultWriteKey andReadKey:kDefaultReadKey];
     XCTAssertNil(client, @"sharedClient with an invalid project id should return nil");


### PR DESCRIPTION
* Cleanup up code inconsistencies where I saw a general preference
* Switched from [[alloc] init] to [new] where appropriate
* Switched from explicitly checking against nil/null to just checking for presence
* Removed unneeded assignment to nil, as it's the default behavior in Objective-C
* Switched to using NS_UNAVAILABLE annotation to indicate no init method, rather than implementing it and raising an assertion. This way user code won't compile with init and they'll be told why.
* Flipped some check logic so that we return early in the negative case, thus collapsing branches and de-indenting code.
* Switched a check to search for object presence first, before calling an external method. This way if we don't have the object we don't waste time making the call.
* Switched from [[alloc] init] for dictionaries and arrays to [dictionary] and [array]
* Removed validate methods that only checked for nil/length of 0. They were being used in ways that made it clear they were misunderstood. Instead just checked for things directly.
* Switched KIOQuery to use [super init] instead of [self init]. This is so that if anyone ever subclasses KIOQuery they will get the expected behavior. If there is some reason it was [self init] please let me know.
* Removed makeDictionaryMutable and makeArrayMutable methods. Instead just use the built-in mutableCopy.
* Removed strong from property declarations as it's the default.
* Changed some error messages to be more explicit about what the problem is.
* Switched from rangeOfString to hasPrefix and containsString.
* Check for existence of self in KeenProperties before setting property values.