### PR TITLE
Breaking changes

### DIFF
--- a/KeenClient/KeenClient.m
+++ b/KeenClient/KeenClient.m
@@ -400,10 +400,8 @@ static BOOL geoLocationRequestEnabled = YES;
             if ([KeenClient isLocationAuthorized:clAuthStatus]) {
                 [self startMonitoringLocation];
             }
-#if __IPHONE_OS_VERSION_MAX_ALLOWED >= 80000
             // Else, try and request permission for that.
-            else if (geoLocationRequestEnabled &&
-                     [self.locationManager respondsToSelector:@selector(requestAlwaysAuthorization)]) {
+            else if (geoLocationRequestEnabled) {
                 // allow explicit control over the type of authorization
                 if(authorizedGeoLocationAlways) {
                     [self.locationManager requestAlwaysAuthorization];
@@ -416,7 +414,6 @@ static BOOL geoLocationRequestEnabled = YES;
                     [self.locationManager requestWhenInUseAuthorization];
                 }
             }
-#endif
         }
 
     } else {

--- a/KeenClient/KeenClient.m
+++ b/KeenClient/KeenClient.m
@@ -356,6 +356,7 @@ static BOOL geoLocationRequestEnabled = YES;
 
     // If the keys are already set, return the existing instance, don't overwrite the keys
     if (self.sharedClient.projectID || self.sharedClient.writeKey || self.sharedClient.readKey) {
+        KCLogError(@"You cannot modify the projectID, writeKey, or readKey from this method.");
         return self.sharedClient;
     }
 

--- a/KeenClient/KeenClient.m
+++ b/KeenClient/KeenClient.m
@@ -354,6 +354,11 @@ static BOOL geoLocationRequestEnabled = YES;
         return nil;
     }
 
+    // If the keys are already set, return the existing instance, don't overwrite the keys
+    if (self.sharedClient.projectID || self.sharedClient.writeKey || self.sharedClient.readKey) {
+        return self.sharedClient;
+    }
+
     self.sharedClient.projectID = projectID;
     self.sharedClient.writeKey = writeKey;
     self.sharedClient.readKey = readKey;

--- a/KeenClientTests/KeenClientTests.m
+++ b/KeenClientTests/KeenClientTests.m
@@ -146,7 +146,7 @@ NSString* kDefaultReadKey = @"rk";
     XCTAssertTrue(client != client2, @"Another init should return a separate instance");
 }
 
-- (void)testSharedClientWithProjectID{
+- (void)testSharedClientWithProjectID {
     KeenClient *client = [KeenClient sharedClientWithProjectID:kDefaultProjectID andWriteKey:kDefaultWriteKey andReadKey:kDefaultReadKey];
     XCTAssertEqual(kDefaultProjectID, client.projectID, @"sharedClientWithProjectID with a non-nil project id should work.");
     XCTAssertEqualObjects(kDefaultWriteKey, client.writeKey, @"init with a valid project id should work");
@@ -154,8 +154,8 @@ NSString* kDefaultReadKey = @"rk";
 
     KeenClient *client2 = [KeenClient sharedClientWithProjectID:@"other" andWriteKey:@"wk2" andReadKey:@"rk2"];
     XCTAssertEqualObjects(client, client2, @"sharedClient should return the same instance");
-    XCTAssertEqualObjects(@"wk2", client2.writeKey, @"sharedClient with a valid project id should work");
-    XCTAssertEqualObjects(@"rk2", client2.readKey, @"sharedClient with a valid project id should work");
+    XCTAssertEqualObjects(kDefaultWriteKey, client2.writeKey, @"sharedClient should not change the writeKey after first init.");
+    XCTAssertEqualObjects(kDefaultReadKey, client2.readKey, @"sharedClient should not change the readKey after first init.");
 
     client = [KeenClient sharedClientWithProjectID:nil andWriteKey:kDefaultWriteKey andReadKey:kDefaultReadKey];
     XCTAssertNil(client, @"sharedClient with an invalid project id should return nil");


### PR DESCRIPTION
Two issues from my previous PR that were deemed breaking, and thus a part of the next major revision.

* Removed iOS 8 specific code after getting permission to do so.
* Removed the ability to call sharedClientWithProjectID:andWriteKey:andReadKey: again and change the keys. Only set the keys if they have not been set.