### PR TITLE
Added missing headers to KeenClientFramework target

### DIFF
--- a/KeenClient.xcodeproj/project.pbxproj
+++ b/KeenClient.xcodeproj/project.pbxproj
@@ -122,6 +122,9 @@
 		F4D3B6061A0D8EB4000825FE /* KIOReachability.m in Sources */ = {isa = PBXBuildFile; fileRef = F4D3B6011A0D8EB4000825FE /* KIOReachability.m */; };
 		F4D3B60A1A0D8EB4000825FE /* KIOReachability.m in Sources */ = {isa = PBXBuildFile; fileRef = F4D3B6011A0D8EB4000825FE /* KIOReachability.m */; };
 		F4D3B61E1A0D98B4000825FE /* SystemConfiguration.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F4D3B61D1A0D98B4000825FE /* SystemConfiguration.framework */; };
+		FA4A14C91EC6236F0002E6CC /* KeenLogger.h in Headers */ = {isa = PBXBuildFile; fileRef = 48583E051E58CDE2002CFD99 /* KeenLogger.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		FA4A14CD1EC623740002E6CC /* KeenLogSinkNSLog.h in Headers */ = {isa = PBXBuildFile; fileRef = 481A9B7A1E5690950094B985 /* KeenLogSinkNSLog.h */; };
+		FA4A14CE1EC623760002E6CC /* KeenLogSink.h in Headers */ = {isa = PBXBuildFile; fileRef = 481A9B711E5687EA0094B985 /* KeenLogSink.h */; settings = {ATTRIBUTES = (Public, ); }; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -556,6 +559,7 @@
 				3EE9A7421C5988F100B7B2D9 /* HTTPCodes.h in Headers */,
 				48AC67D81E833C2D00E9C0A9 /* KIONetwork.h in Headers */,
 				3EE9A7431C5988F100B7B2D9 /* KeenClient.h in Headers */,
+				FA4A14CD1EC623740002E6CC /* KeenLogSinkNSLog.h in Headers */,
 				48AC67CD1E83364100E9C0A9 /* KIOFileStore.h in Headers */,
 				3EE9A7441C5988F100B7B2D9 /* KeenProperties.h in Headers */,
 				48AC67E01E8348BA00E9C0A9 /* KIOUploader.h in Headers */,
@@ -563,7 +567,9 @@
 				3EE9A7471C5988F100B7B2D9 /* KIOQuery.h in Headers */,
 				480FEB731E846F7500641112 /* KIOUtil.h in Headers */,
 				3EE9A7401C5988F100B7B2D9 /* keen_io_sqlite3.h in Headers */,
+				FA4A14CE1EC623760002E6CC /* KeenLogSink.h in Headers */,
 				3EE9A7411C5988F100B7B2D9 /* keen_io_sqlite3ext.h in Headers */,
+				FA4A14C91EC6236F0002E6CC /* KeenLogger.h in Headers */,
 				3EE9A7451C5988F100B7B2D9 /* KeenConstants.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/KeenClient.xcodeproj/project.pbxproj
+++ b/KeenClient.xcodeproj/project.pbxproj
@@ -88,7 +88,7 @@
 		482CB31D1E552F5300FCFACF /* corrupt.sqlite in Resources */ = {isa = PBXBuildFile; fileRef = 482CB31C1E552F5300FCFACF /* corrupt.sqlite */; };
 		48472CA51E9C526400DB3B41 /* KeenLogger.m in Sources */ = {isa = PBXBuildFile; fileRef = 48583E061E58CDE2002CFD99 /* KeenLogger.m */; };
 		48472CA91E9C52D700DB3B41 /* KeenLogSinkNSLog.m in Sources */ = {isa = PBXBuildFile; fileRef = 481A9B7B1E5690950094B985 /* KeenLogSinkNSLog.m */; };
-		48583E071E58CDE2002CFD99 /* KeenLogger.h in Headers */ = {isa = PBXBuildFile; fileRef = 48583E051E58CDE2002CFD99 /* KeenLogger.h */; };
+		48583E071E58CDE2002CFD99 /* KeenLogger.h in Headers */ = {isa = PBXBuildFile; fileRef = 48583E051E58CDE2002CFD99 /* KeenLogger.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		48583E081E58CDE2002CFD99 /* KeenLogger.m in Sources */ = {isa = PBXBuildFile; fileRef = 48583E061E58CDE2002CFD99 /* KeenLogger.m */; };
 		48583E0F1E5904FD002CFD99 /* KeenLoggerTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 48583E0E1E5904FD002CFD99 /* KeenLoggerTests.m */; };
 		48AC67CB1E83364100E9C0A9 /* KIOFileStore.h in Headers */ = {isa = PBXBuildFile; fileRef = 48AC67C91E83364100E9C0A9 /* KIOFileStore.h */; };
@@ -125,6 +125,9 @@
 		FA4A14C91EC6236F0002E6CC /* KeenLogger.h in Headers */ = {isa = PBXBuildFile; fileRef = 48583E051E58CDE2002CFD99 /* KeenLogger.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		FA4A14CD1EC623740002E6CC /* KeenLogSinkNSLog.h in Headers */ = {isa = PBXBuildFile; fileRef = 481A9B7A1E5690950094B985 /* KeenLogSinkNSLog.h */; };
 		FA4A14CE1EC623760002E6CC /* KeenLogSink.h in Headers */ = {isa = PBXBuildFile; fileRef = 481A9B711E5687EA0094B985 /* KeenLogSink.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		FA4A14E51EC629860002E6CC /* KeenLogSink.h in Headers */ = {isa = PBXBuildFile; fileRef = 481A9B711E5687EA0094B985 /* KeenLogSink.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		FA4A14E91EC6298A0002E6CC /* KeenLogSinkNSLog.h in Headers */ = {isa = PBXBuildFile; fileRef = 481A9B7A1E5690950094B985 /* KeenLogSinkNSLog.h */; };
+		FA4A14EA1EC6298D0002E6CC /* KeenLogger.h in Headers */ = {isa = PBXBuildFile; fileRef = 48583E051E58CDE2002CFD99 /* KeenLogger.h */; settings = {ATTRIBUTES = (Public, ); }; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -539,12 +542,15 @@
 				1296399019C10D0000B2B653 /* KeenClient.h in Headers */,
 				48AC67DF1E8348BA00E9C0A9 /* KIOUploader.h in Headers */,
 				1296399119C10D0000B2B653 /* KeenProperties.h in Headers */,
+				FA4A14EA1EC6298D0002E6CC /* KeenLogger.h in Headers */,
 				1296399319C10D0000B2B653 /* KIODBStore.h in Headers */,
 				48AC67D71E833C2D00E9C0A9 /* KIONetwork.h in Headers */,
 				125D31A91B0E335300DFCC97 /* HTTPCodes.h in Headers */,
 				F4D3B6051A0D8EB4000825FE /* KIOReachability.h in Headers */,
 				12AE4C3C1B4AD2880015F41F /* KIOQuery.h in Headers */,
+				FA4A14E91EC6298A0002E6CC /* KeenLogSinkNSLog.h in Headers */,
 				1296398E19C10D0000B2B653 /* keen_io_sqlite3.h in Headers */,
+				FA4A14E51EC629860002E6CC /* KeenLogSink.h in Headers */,
 				1296398F19C10D0000B2B653 /* keen_io_sqlite3ext.h in Headers */,
 				1296399219C10D0000B2B653 /* KeenConstants.h in Headers */,
 			);


### PR DESCRIPTION
* Added headers missing in KeenClientFramework target that are present in KeenClient target, with appropriate access levels:  
	⁃ `KeenLogSink.h` _(Public, matching KeenClient)_  
	⁃ `KeenLogSinkNSLog.h` _(Project, matching KeenClient)_  
	⁃ `KeenLogger.h` _(Public, because `KeenClient.h` imports it)_

Fixes #216