### PR TITLE
3.6.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
 
+## [3.6.1] - 2017-05-12
+### Fixed
+- Fixed missing headers from framework build
+
 ## [3.6.0] - 2017-04-05
 ### Added
 - Extensibility hooks for custom logging implementations.

--- a/KeenClient.podspec
+++ b/KeenClient.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |spec|
   spec.name         = 'KeenClient'
-  spec.version      = '3.6.0'
+  spec.version      = '3.6.1'
   spec.license      = { :type => 'MIT' }
   spec.ios.deployment_target = '6.0'
   spec.osx.deployment_target = '10.9'

--- a/KeenClient/KeenConstants.h
+++ b/KeenClient/KeenConstants.h
@@ -8,7 +8,7 @@
 
 #import <Foundation/Foundation.h>
 
-#define kKeenSdkVersion @"3.6.0"
+#define kKeenSdkVersion @"3.6.1"
 
 extern NSString * const kKeenServerAddress;
 extern NSString * const kKeenApiVersion;

--- a/KeenClientFramework/Info.plist
+++ b/KeenClientFramework/Info.plist
@@ -15,11 +15,11 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>3.6.0</string>
+	<string>3.6.1</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>
-	<string>3.6.0</string>
+	<string>3.6.1</string>
 	<key>NSPrincipalClass</key>
 	<string></string>
 </dict>


### PR DESCRIPTION
Includes a fix to public headers that were missing from the framework build which breaks Carthage projects.