### PR TITLE
Fix documentation warnings.

### DIFF
--- a/KeenClient/KIODBStore.h
+++ b/KeenClient/KIODBStore.h
@@ -30,7 +30,8 @@
   Add an event to the store.
 
   @param eventData Your event data.
-  @param coll Your event collection.
+  @param eventCollection Your event collection.
+  @param projectID Project ID to add the event to.
   */
 - (BOOL)addEvent:(NSData *)eventData collection:(NSString *)eventCollection projectID:(NSString *)projectID;
 

--- a/KeenClient/KIOUploader.m
+++ b/KeenClient/KIOUploader.m
@@ -26,7 +26,7 @@
  and then removing any events from the local filesystem that have been handled by the keen API.
  @param response The response from the server.
  @param responseData The data returned from the server.
- @param eventPaths A dictionary that maps events to their paths on the file system.
+ @param eventIds A dictionary that maps events to their ID's in the local store.
  */
 - (void)handleEventAPIResponse:(NSURLResponse *)response
                        andData:(NSData *)responseData

--- a/KeenClient/KeenClient.h
+++ b/KeenClient/KeenClient.h
@@ -197,7 +197,7 @@ typedef NSDictionary* (^KeenGlobalPropertiesBlock)(NSString *eventCollection);
 
  @return An instance of KIOEventStore.
  */
-+ (KIODBStore *)getDBStore DEPRECATED_MSG_ATTRIBUTE("Class method getDBStore is deprecated. User instance method instead.");
++ (KIODBStore *)getDBStore DEPRECATED_MSG_ATTRIBUTE("Class method getDBStore is deprecated. Use instance method instead.");
 - (KIODBStore *)getDBStore;
 
 /**
@@ -320,8 +320,7 @@ typedef NSDictionary* (^KeenGlobalPropertiesBlock)(NSString *eventCollection);
  This method is only used for testing.
 
  @param keenQuery The KIOQuery object containing the information about the query.
- @param returningResponse The NSURLResponse for the query.
- @param error The NSError (if any) for the query.
+ @param completionHandler The block to call upon completion of the query.
  */
 - (void)runQuery:(KIOQuery *)keenQuery completionHandler:(void (^)(NSData *data, NSURLResponse *response, NSError *error))completionHandler;
 
@@ -331,8 +330,7 @@ typedef NSDictionary* (^KeenGlobalPropertiesBlock)(NSString *eventCollection);
  This method is only used for testing.
 
  @param keenQueries The NSArray object containing multiple KIOQuery objects. They must all contain the same value for the event_collection property.
- @param returningResponse The NSURLResponse for the query.
- @param error The NSError (if any) for the query.
+ @param completionHandler The block to call upon completion of the query.
  */
 - (void)runMultiAnalysisWithQueries:(NSArray *)keenQueries completionHandler:(void (^)(NSData *data, NSURLResponse *response, NSError *error))completionHandler;
 


### PR DESCRIPTION
One more thing required for releasing 3.6.1. There were a few mistakes in documentation comments producing compiler warnings.