### PR TITLE
Fix duplicated events with multiple upload calls

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -44,7 +44,7 @@ matrix:
 
 before_install:
   - gem install bundler
-  - rvm use 2.3.0
+  - rvm use 2.4.1
 
 script: ./bin/test.sh
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,14 +9,14 @@ xcode_scheme:
   - KeenClientFramework
 xcode_sdk: iphonesimulator10.3
 env:
-  - XCODEBUILD_PLATFORM='iOS Simulator' XCODEBUILD_SIM_OS=10.3 XCODEBUILD_DEVICE='iPhone 6' XCODEBUILD_ACTION=build
+  - XCODEBUILD_PLATFORM='iOS Simulator' XCODEBUILD_SIM_OS=10.3.1 XCODEBUILD_DEVICE='iPhone 6' XCODEBUILD_ACTION=build
 
 matrix:
   include:
     - xcode_scheme: KeenClient
       xcode_sdk: iphonesimulator10.3
       env:
-        - XCODEBUILD_PLATFORM='iOS Simulator' XCODEBUILD_SIM_OS=10.3 XCODEBUILD_DEVICE='iPhone 6' XCODEBUILD_ACTION=test
+        - XCODEBUILD_PLATFORM='iOS Simulator' XCODEBUILD_SIM_OS=10.3.1 XCODEBUILD_DEVICE='iPhone 6' XCODEBUILD_ACTION=test
     - xcode_scheme: KeenClient
       xcode_sdk: iphonesimulator10.3
       env:
@@ -31,16 +31,16 @@ matrix:
         - XCODEBUILD_PLATFORM='OS X' XCODEBUILD_ACTION=build
     - xcode_scheme: KeenClientExampleObjCCocoaPods
       xcode_sdk: iphonesimulator10.3
-      env: POD_INSTALL=true XCODEBUILD_WORKSPACE=Examples/objc/cocoapods/KeenClientExampleObjCCocoaPods.xcworkspace XCODEBUILD_PLATFORM='iOS Simulator' XCODEBUILD_SIM_OS=10.3 XCODEBUILD_DEVICE='iPhone 6' XCODEBUILD_ACTION=build
+      env: POD_INSTALL=true XCODEBUILD_WORKSPACE=Examples/objc/cocoapods/KeenClientExampleObjCCocoaPods.xcworkspace XCODEBUILD_PLATFORM='iOS Simulator' XCODEBUILD_SIM_OS=10.3.1 XCODEBUILD_DEVICE='iPhone 6' XCODEBUILD_ACTION=build
     - xcode_scheme: KeenClientExampleObjCCarthage
       xcode_sdk: iphonesimulator10.3
-      env: CARTHAGE_INSTALL=true XCODEBUILD_PROJECT=Examples/objc/carthage/KeenClientExampleObjCCarthage.xcodeproj XCODEBUILD_PROJECT_TARGET=KeenClientExampleObjCCarthage XCODEBUILD_PLATFORM='iOS Simulator' XCODEBUILD_SIM_OS=10.3 XCODEBUILD_DEVICE='iPhone 6' XCODEBUILD_ACTION=build
+      env: CARTHAGE_INSTALL=true XCODEBUILD_PROJECT=Examples/objc/carthage/KeenClientExampleObjCCarthage.xcodeproj XCODEBUILD_PROJECT_TARGET=KeenClientExampleObjCCarthage XCODEBUILD_PLATFORM='iOS Simulator' XCODEBUILD_SIM_OS=10.3.1 XCODEBUILD_DEVICE='iPhone 6' XCODEBUILD_ACTION=build
     - xcode_scheme: KeenClientExampleSwiftCocoaPods
       xcode_sdk: iphonesimulator10.3
-      env: POD_INSTALL=true XCODEBUILD_WORKSPACE=Examples/swift/cocoapods/KeenClientExampleSwiftCocoaPods.xcworkspace XCODEBUILD_PLATFORM='iOS Simulator' XCODEBUILD_SIM_OS=10.3 XCODEBUILD_DEVICE='iPhone 6' XCODEBUILD_ACTION=build
+      env: POD_INSTALL=true XCODEBUILD_WORKSPACE=Examples/swift/cocoapods/KeenClientExampleSwiftCocoaPods.xcworkspace XCODEBUILD_PLATFORM='iOS Simulator' XCODEBUILD_SIM_OS=10.3.1 XCODEBUILD_DEVICE='iPhone 6' XCODEBUILD_ACTION=build
     - xcode_scheme: KeenClientExampleSwiftCarthage
       xcode_sdk: iphonesimulator10.3
-      env: CARTHAGE_INSTALL=true XCODEBUILD_PROJECT=Examples/swift/carthage/KeenClientExampleSwiftCarthage.xcodeproj XCODEBUILD_PROJECT_TARGET=KeenClientExampleSwiftCarthage XCODEBUILD_PLATFORM='iOS Simulator' XCODEBUILD_SIM_OS=10.3 XCODEBUILD_DEVICE='iPhone 6' XCODEBUILD_ACTION=build
+      env: CARTHAGE_INSTALL=true XCODEBUILD_PROJECT=Examples/swift/carthage/KeenClientExampleSwiftCarthage.xcodeproj XCODEBUILD_PROJECT_TARGET=KeenClientExampleSwiftCarthage XCODEBUILD_PLATFORM='iOS Simulator' XCODEBUILD_SIM_OS=10.3.1 XCODEBUILD_DEVICE='iPhone 6' XCODEBUILD_ACTION=build
 
 before_install:
   - gem install bundler

--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,5 @@
 source 'https://rubygems.org'
-ruby '2.3.0'
+ruby '2.4.1'
 
 gem 'slather'
 gem 'xcpretty'

--- a/KeenClient.xcodeproj/project.pbxproj
+++ b/KeenClient.xcodeproj/project.pbxproj
@@ -82,6 +82,7 @@
 		480FEB741E846F7500641112 /* KIOUtil.m in Sources */ = {isa = PBXBuildFile; fileRef = 480FEB701E846F7500641112 /* KIOUtil.m */; };
 		480FEB751E846F7500641112 /* KIOUtil.m in Sources */ = {isa = PBXBuildFile; fileRef = 480FEB701E846F7500641112 /* KIOUtil.m */; };
 		480FEB761E846F7500641112 /* KIOUtil.m in Sources */ = {isa = PBXBuildFile; fileRef = 480FEB701E846F7500641112 /* KIOUtil.m */; };
+		481794741EE8F66500586007 /* MockNSURLSession.m in Sources */ = {isa = PBXBuildFile; fileRef = 481794731EE8F66500586007 /* MockNSURLSession.m */; };
 		481A9B7C1E5690950094B985 /* KeenLogSinkNSLog.h in Headers */ = {isa = PBXBuildFile; fileRef = 481A9B7A1E5690950094B985 /* KeenLogSinkNSLog.h */; };
 		481A9B7D1E5690950094B985 /* KeenLogSinkNSLog.m in Sources */ = {isa = PBXBuildFile; fileRef = 481A9B7B1E5690950094B985 /* KeenLogSinkNSLog.m */; };
 		481A9B7E1E5691270094B985 /* KeenLogSink.h in Headers */ = {isa = PBXBuildFile; fileRef = 481A9B711E5687EA0094B985 /* KeenLogSink.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -193,6 +194,8 @@
 		3EE9A7301C59873F00B7B2D9 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		480FEB6F1E846F7500641112 /* KIOUtil.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = KIOUtil.h; sourceTree = "<group>"; };
 		480FEB701E846F7500641112 /* KIOUtil.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = KIOUtil.m; sourceTree = "<group>"; };
+		481794721EE8F66500586007 /* MockNSURLSession.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MockNSURLSession.h; sourceTree = "<group>"; };
+		481794731EE8F66500586007 /* MockNSURLSession.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MockNSURLSession.m; sourceTree = "<group>"; };
 		481A9B711E5687EA0094B985 /* KeenLogSink.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = KeenLogSink.h; sourceTree = "<group>"; };
 		481A9B7A1E5690950094B985 /* KeenLogSinkNSLog.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = KeenLogSinkNSLog.h; sourceTree = "<group>"; };
 		481A9B7B1E5690950094B985 /* KeenLogSinkNSLog.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = KeenLogSinkNSLog.m; sourceTree = "<group>"; };
@@ -383,6 +386,8 @@
 				3E63D9F61AE7425000E57A17 /* KIOQueryTests.m */,
 				48583E0D1E5904FD002CFD99 /* KeenLoggerTests.h */,
 				48583E0E1E5904FD002CFD99 /* KeenLoggerTests.m */,
+				481794721EE8F66500586007 /* MockNSURLSession.h */,
+				481794731EE8F66500586007 /* MockNSURLSession.m */,
 			);
 			path = KeenClientTests;
 			sourceTree = "<group>";
@@ -713,6 +718,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				481794741EE8F66500586007 /* MockNSURLSession.m in Sources */,
 				CA6410E218E39F3A00E53E3C /* KIODBStoreTests.m in Sources */,
 				3E63D9F71AE7425000E57A17 /* KIOQueryTests.m in Sources */,
 				48583E0F1E5904FD002CFD99 /* KeenLoggerTests.m in Sources */,

--- a/KeenClientTests/MockNSURLSession.h
+++ b/KeenClientTests/MockNSURLSession.h
@@ -1,0 +1,21 @@
+//
+//  MockNSURLSession.h
+//  KeenClient
+//
+//  Created by Brian Baumhover on 6/7/17.
+//  Copyright © 2017 Keen Labs. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+@interface MockNSURLSession : NSObject
+
+- (instancetype)initWithValidator:(BOOL (^)(id requestObject))validator data:(NSData *)data response:(NSURLResponse *)response error:(NSError *)error;
+
+- (NSURLSessionDataTask *)dataTaskWithRequest:(NSURLRequest *)request
+                            completionHandler:(void (^)(NSData *_Nullable data,
+                                                        NSURLResponse *_Nullable response,
+                                                        NSError *_Nullable error))completionHandler;
+
+@end
+

--- a/KeenClientTests/MockNSURLSession.m
+++ b/KeenClientTests/MockNSURLSession.m
@@ -1,0 +1,53 @@
+//
+//  MockNSURLSession.m
+//  KeenClient
+//
+//  Created by Brian Baumhover on 6/7/17.
+//  Copyright © 2017 Keen Labs. All rights reserved.
+//
+
+#import <XCTest/XCTest.h>
+
+#import "MockNSURLSession.h"
+
+@interface MockNSURLSession ()
+
+@property NSData* data;
+@property NSURLResponse* response;
+@property NSError* error;
+@property BOOL (^validator)(id requestObject);
+
+@end
+
+@implementation MockNSURLSession
+
+- (instancetype)initWithValidator:(BOOL (^)(id requestObject))validator data:(NSData *)data response:(NSURLResponse *)response error:(NSError *)error {
+    self = [super init];
+
+    if (self) {
+        self.validator = validator;
+        self.data = data;
+        self.response = response;
+        self.error = error;
+    }
+
+    return self;
+}
+
+- (NSURLSessionDataTask *)dataTaskWithRequest:(NSURLRequest *)request
+                            completionHandler:(void (^)(NSData *_Nullable data,
+                                                        NSURLResponse *_Nullable response,
+                                                        NSError *_Nullable error))completionHandler {
+    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(10 * NSEC_PER_MSEC)), dispatch_get_main_queue(), ^{
+        if (self.validator) {
+            if (!self.validator(request)) {
+                [NSException raise:@"TestException" format:@"Request validator failed validation."];
+            }
+        }
+        completionHandler(self.data, self.response, self.error);
+    });
+
+    return nil;
+}
+
+@end


### PR DESCRIPTION
Fix a problem where multiple calls to uploadWithFinishedBlock: can cause duplicate uploads when a subsequent call starts uploading before a prior call finishes and deletes successfully uploaded events.