### PR TITLE
Make `timestamp` include milliseconds, report upload errors, and include prior attempts count in uploaded events

### DIFF
--- a/KeenClient/KIOUploader.h
+++ b/KeenClient/KIOUploader.h
@@ -23,6 +23,6 @@
 - (instancetype)initWithNetwork:(KIONetwork *)network andStore:(KIODBStore *)store;
 
 // Upload events in the store for a given project
-- (void)uploadEventsForConfig:(KeenClientConfig *)config completionHandler:(void (^)())completionHandler;
+- (void)uploadEventsForConfig:(KeenClientConfig *)config completionHandler:(UploadCompletionBlock)completionHandler;
 
 @end

--- a/KeenClient/KIOUploader.m
+++ b/KeenClient/KIOUploader.m
@@ -216,6 +216,7 @@
                               config:config
                    completionHandler:^(NSData *data, NSURLResponse *response, NSError *responseError) {
                        NSError *localError;
+                       KCLogInfo(@"Got upload completion callback.");
                        // then parse the http response and deal with it appropriately
                        [self handleEventAPIResponse:response
                                             andData:data

--- a/KeenClient/KIOUploader.m
+++ b/KeenClient/KIOUploader.m
@@ -125,14 +125,8 @@
                 return;
             }
 
-            // Get a mutable copy of dictionary with keen properties
-            NSMutableDictionary *keenDictionary = [eventDict[kKeenEventKeenDataKey] mutableCopy];
-
             // Add information about the attempt count
-            [keenDictionary addEntriesFromDictionary:@{kKeenEventKeenDataAttemptsKey: eventAttempts}];
-
-            // Replace the existing dictionary with the new one including upload attempts
-            eventDict[kKeenEventKeenDataKey] = keenDictionary;
+            [eventDict addEntriesFromDictionary:@{kKeenEventKeenDataAttemptsKey: eventAttempts}];
 
             // add it to the array of events
             [eventsArray addObject:eventDict];
@@ -197,10 +191,13 @@
         NSMutableDictionary *eventIDs;
         [self prepareJSONData:&data andEventIDs:&eventIDs forProjectID:config.projectID error:&error];
         if (error != nil) {
+            KCLogInfo(@"Error preparing JSON data for upload: %@", error);
             [self runUploadFinishedBlock:completionHandler error:error];
         } else if ([data length] == 0) {
+            KCLogInfo(@"No data available for upload.");
             [self runUploadFinishedBlock:completionHandler error:nil];
         } else {
+            KCLogInfo(@"Uploading %@ events...", @([eventIDs count]));
             // loop through events and increment their attempt count
             for (NSString *collectionName in eventIDs) {
                 for (NSNumber *eid in eventIDs[collectionName]) {
@@ -246,6 +243,9 @@
 - (void)runUploadFinishedBlock:(UploadCompletionBlock)completionBlock error:(NSError *)error {
     if (completionBlock) {
         KCLogVerbose(@"Running user-specified block.");
+        if (nil != error) {
+            KCLogError(@"Error uploading events: %@", error);
+        }
         completionBlock(error);
     }
 }

--- a/KeenClient/KIOUploader.m
+++ b/KeenClient/KIOUploader.m
@@ -197,13 +197,15 @@
             KCLogInfo(@"No data available for upload.");
             [self runUploadFinishedBlock:completionHandler error:nil];
         } else {
-            KCLogInfo(@"Uploading %@ events...", @([eventIDs count]));
+            NSUInteger eventCount = 0;
             // loop through events and increment their attempt count
             for (NSString *collectionName in eventIDs) {
                 for (NSNumber *eid in eventIDs[collectionName]) {
                     [self.store incrementEventUploadAttempts:eid];
                 }
+                eventCount += [eventIDs[collectionName] count];
             }
+            KCLogInfo(@"Uploading %@ events...", @(eventCount));
 
             [self.isUploadingCondition lock];
             self.isUploading = YES;

--- a/KeenClient/KIOUploader.m
+++ b/KeenClient/KIOUploader.m
@@ -15,12 +15,13 @@
 #import "KIONetwork.h"
 #import "KIOFileStore.h"
 #import "KIOUploader.h"
+#import "KIOUtil.h"
 
 @interface KIOUploader ()
 
 - (BOOL)isNetworkConnected;
 
-- (void)runUploadFinishedBlock:(void (^)())block;
+- (void)runUploadFinishedBlock:(UploadCompletionBlock)completionBlock error:(NSError *)error;
 
 /**
  Handles the HTTP response from the Keen Event API.  This involves deserializing the JSON response
@@ -31,7 +32,9 @@
  */
 - (void)handleEventAPIResponse:(NSURLResponse *)response
                        andData:(NSData *)responseData
-                     forEvents:(NSDictionary *)eventIds;
+                     forEvents:(NSDictionary *)eventIds
+                 responseError:(NSError *)responseError
+                         error:(NSError **)error;
 
 // A dispatch queue used for uploads.
 @property (nonatomic) dispatch_queue_t uploadQueue;
@@ -87,7 +90,10 @@
 
 - (void)prepareJSONData:(NSData **)jsonData
             andEventIDs:(NSMutableDictionary **)eventIDs
-           forProjectID:(NSString *)projectID {
+           forProjectID:(NSString *)projectID
+                  error:(NSError **)ppError {
+    NSError *error;
+
     // set up the request dictionary we'll send out.
     NSMutableDictionary *requestDict = [NSMutableDictionary dictionary];
 
@@ -98,31 +104,46 @@
     NSMutableDictionary *events =
         [self.store getEventsWithMaxAttempts:self.maxEventUploadAttempts andProjectID:projectID];
 
-    NSError *error;
-    for (NSString *coll in events) {
-        NSDictionary *collEvents = [events objectForKey:coll];
+    for (NSString *collection in events) {
+        NSDictionary *collectionEvents = events[collection];
 
         // create a separate array for event data so our dictionary serializes properly
         NSMutableArray *eventsArray = [NSMutableArray array];
 
-        for (NSNumber *eid in collEvents) {
-            NSData *ev = [collEvents objectForKey:eid];
-            NSDictionary *eventDict = [NSJSONSerialization JSONObjectWithData:ev options:0 error:&error];
+        for (NSNumber *eventId in collectionEvents) {
+            NSDictionary *eventDictionary = collectionEvents[eventId];
+            NSData *eventData = eventDictionary[@"data"];
+            NSNumber *eventAttempts = eventDictionary[kKeenEventKeenDataAttemptsKey];
+
+            NSMutableDictionary *eventDict =
+                [[NSJSONSerialization JSONObjectWithData:eventData options:0 error:&error] mutableCopy];
             if (error) {
                 KCLogError(@"An error occurred when deserializing a saved event: %@", [error localizedDescription]);
-                continue;
+                *ppError = [NSError errorWithDomain:kKeenErrorDomain
+                                               code:KeenErrorCodeSerialization
+                                           userInfo:@{kKeenErrorInnerErrorKey: error}];
+                return;
             }
+
+            // Get a mutable copy of dictionary with keen properties
+            NSMutableDictionary *keenDictionary = [eventDict[kKeenEventKeenDataKey] mutableCopy];
+
+            // Add information about the attempt count
+            [keenDictionary addEntriesFromDictionary:@{kKeenEventKeenDataAttemptsKey: eventAttempts}];
+
+            // Replace the existing dictionary with the new one including upload attempts
+            eventDict[kKeenEventKeenDataKey] = keenDictionary;
 
             // add it to the array of events
             [eventsArray addObject:eventDict];
-            if ([eventIDDict objectForKey:coll] == nil) {
-                [eventIDDict setObject:[NSMutableArray array] forKey:coll];
+            if (eventIDDict[collection] == nil) {
+                eventIDDict[collection] = [NSMutableArray array];
             }
-            [[eventIDDict objectForKey:coll] addObject:eid];
+            [eventIDDict[collection] addObject:eventId];
         }
 
         // add the array of events to the request
-        [requestDict setObject:eventsArray forKey:coll];
+        requestDict[collection] = eventsArray;
     }
 
     if ([requestDict count] == 0) {
@@ -134,7 +155,9 @@
     if (error) {
         KCLogError(@"An error occurred when serializing the final request data back to JSON: %@",
                    [error localizedDescription]);
-        // can't do much here.
+        *ppError = [NSError errorWithDomain:kKeenErrorDomain
+                                       code:KeenErrorCodeSerialization
+                                   userInfo:@{kKeenErrorInnerErrorKey: error}];
         return;
     }
 
@@ -151,10 +174,17 @@
     return [hostReachability KIOcurrentReachabilityStatus] != NotReachable;
 }
 
-- (void)uploadEventsForConfig:(KeenClientConfig *)config completionHandler:(void (^)())completionHandler {
+- (void)uploadEventsForConfig:(KeenClientConfig *)config completionHandler:(UploadCompletionBlock)completionHandler {
     dispatch_async(self.uploadQueue, ^{
+        NSError *error;
+
         if (![self isNetworkConnected]) {
-            [self runUploadFinishedBlock:completionHandler];
+            error = [NSError errorWithDomain:kKeenErrorDomain
+                                        code:KeenErrorCodeNetworkDisconnected
+                                    userInfo:@{
+                                        kKeenErrorDescriptionKey: @"Network is disconnected"
+                                    }];
+            [self runUploadFinishedBlock:completionHandler error:error];
             return;
         }
 
@@ -165,10 +195,11 @@
         // get data for the API request we'll make
         NSData *data;
         NSMutableDictionary *eventIDs;
-        [self prepareJSONData:&data andEventIDs:&eventIDs forProjectID:config.projectID];
-
-        if ([data length] == 0) {
-            [self runUploadFinishedBlock:completionHandler];
+        [self prepareJSONData:&data andEventIDs:&eventIDs forProjectID:config.projectID error:&error];
+        if (error != nil) {
+            [self runUploadFinishedBlock:completionHandler error:error];
+        } else if ([data length] == 0) {
+            [self runUploadFinishedBlock:completionHandler error:nil];
         } else {
             // loop through events and increment their attempt count
             for (NSString *collectionName in eventIDs) {
@@ -184,11 +215,16 @@
             // then make an http request to the keen server.
             [self.network sendEvents:data
                               config:config
-                   completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
+                   completionHandler:^(NSData *data, NSURLResponse *response, NSError *responseError) {
+                       NSError *localError;
                        // then parse the http response and deal with it appropriately
-                       [self handleEventAPIResponse:response andData:data forEvents:eventIDs];
+                       [self handleEventAPIResponse:response
+                                            andData:data
+                                          forEvents:eventIDs
+                                      responseError:responseError
+                                              error:&localError];
 
-                       [self runUploadFinishedBlock:completionHandler];
+                       [self runUploadFinishedBlock:completionHandler error:localError];
 
                        [self.isUploadingCondition lock];
                        self.isUploading = NO;
@@ -207,10 +243,10 @@
     });
 }
 
-- (void)runUploadFinishedBlock:(void (^)())block {
-    if (block) {
+- (void)runUploadFinishedBlock:(UploadCompletionBlock)completionBlock error:(NSError *)error {
+    if (completionBlock) {
         KCLogVerbose(@"Running user-specified block.");
-        block();
+        completionBlock(error);
     }
 }
 
@@ -218,33 +254,70 @@
 
 - (void)handleEventAPIResponse:(NSURLResponse *)response
                        andData:(NSData *)responseData
-                     forEvents:(NSDictionary *)eventIds {
-    if (!responseData) {
-        KCLogError(@"responseData was nil for some reason.  That's not great.");
-        KCLogError(@"response status code: %ld", (long)[((NSHTTPURLResponse *)response)statusCode]);
+                     forEvents:(NSDictionary *)eventIds
+                 responseError:(NSError *)responseError
+                         error:(NSError **)ppError {
+    NSError *error;
+
+    // If there was a response error, return it
+    if (nil != responseError) {
+        *ppError = [NSError errorWithDomain:kKeenErrorDomain
+                                       code:KeenErrorCodeResponseError
+                                   userInfo:@{kKeenErrorInnerErrorKey: responseError}];
         return;
     }
+
     NSInteger responseCode = [((NSHTTPURLResponse *)response)statusCode];
     if ([HTTPCodes httpCodeType:(responseCode)] != HTTPCode2XXSuccess) {
         // response code was NOT 2xx, which means something else happened. log this.
-        KCLogError(@"Response code was NOT 2xx. It was: %ld", (long)responseCode);
-        NSString *responseString = [[NSString alloc] initWithData:responseData encoding:NSUTF8StringEncoding];
-        KCLogError(@"Response body was: %@", responseString);
+        NSString *responseString =
+            responseData ? [[NSString alloc] initWithData:responseData encoding:NSUTF8StringEncoding] : @"";
+        NSString *errorDescription =
+            [NSString stringWithFormat:@"Response returned non-success code: %@\nResponse body was: %@",
+                                       @(responseCode),
+                                       responseString];
+        KCLogError(@"%@", errorDescription);
+        *ppError = [NSError errorWithDomain:kKeenErrorDomain
+                                       code:KeenErrorCodeResponseError
+                                   userInfo:@{
+                                       kKeenErrorDescriptionKey: errorDescription,
+                                       kKeenErrorHttpStatus: @(responseCode)
+                                   }];
+        return;
+    }
+
+    // If for some reason there was no response body and no error, generate an error and return it
+    if (!responseData) {
+        KCLogError(@"responseData was nil for some reason.  That's not great.");
+        KCLogError(@"response status code: %ld", (long)[((NSHTTPURLResponse *)response)statusCode]);
+        *ppError = [NSError errorWithDomain:kKeenErrorDomain
+                                       code:KeenErrorCodeResponseError
+                                   userInfo:@{
+                                       kKeenErrorDescriptionKey: @"Response body was empty"
+                                   }];
         return;
     }
 
     // if the request succeeded, dig into the response to figure out which events succeeded and which failed
     // deserialize the response
-    NSError *error;
     NSDictionary *responseDict = [NSJSONSerialization JSONObjectWithData:responseData options:0 error:&error];
     if (error) {
         NSString *responseString = [[NSString alloc] initWithData:responseData encoding:NSUTF8StringEncoding];
-        KCLogError(@"An error occurred when deserializing HTTP response JSON into dictionary.\nError: %@\nResponse: %@",
-                   [error localizedDescription],
-                   responseString);
+        NSString *errorDescription = [NSString
+            stringWithFormat:
+                @"An error occurred when deserializing HTTP response JSON into dictionary.\nError: %@\nResponse: %@",
+                [error localizedDescription],
+                responseString];
+        KCLogError(@"%@", errorDescription);
+        *ppError = [NSError errorWithDomain:kKeenErrorDomain
+                                       code:KeenErrorCodeSerialization
+                                   userInfo:@{kKeenErrorDescriptionKey: errorDescription}];
+
         return;
     }
+
     // now iterate through the keys of the response, which represent collection names
+    NSMutableArray *errors = [NSMutableArray array];
     NSArray *collectionNames = [responseDict allKeys];
     for (NSString *collectionName in collectionNames) {
         // grab the results for this collection
@@ -253,35 +326,59 @@
         // (making sure to keep any failures due to server error)
         NSUInteger count = 0;
         for (NSDictionary *result in results) {
-            BOOL deleteFile = YES;
+            BOOL deleteEvent = YES;
             BOOL success = [[result objectForKey:kKeenSuccessParam] boolValue];
             if (!success) {
                 // grab error code and description
-                NSDictionary *errorDict = [result objectForKey:kKeenErrorParam];
-                NSString *errorCode = [errorDict objectForKey:kKeenNameParam];
-                if ([errorCode isEqualToString:kKeenInvalidCollectionNameError] ||
-                    [errorCode isEqualToString:kKeenInvalidPropertyNameError] ||
-                    [errorCode isEqualToString:kKeenInvalidPropertyValueError]) {
-                    KCLogError(@"An invalid event was found.  Deleting it.  Error: %@",
-                               [errorDict objectForKey:kKeenDescriptionParam]);
-                    deleteFile = YES;
+                NSString *errorDescription;
+                NSDictionary *errorDict = result[kKeenResponseErrorDictionaryKey];
+                NSString *errorName = errorDict[kKeenResponseErrorNameKey];
+
+                if ([errorName isEqualToString:kKeenInvalidCollectionNameError] ||
+                    [errorName isEqualToString:kKeenInvalidPropertyNameError] ||
+                    [errorName isEqualToString:kKeenInvalidPropertyValueError]) {
+                    errorDescription = [NSString
+                        stringWithFormat:@"An invalid event was found. Deleting it. Error name and description: %@, %@",
+                                         errorName,
+                                         errorDict[kKeenResponseErrorDescriptionKey]];
+                    deleteEvent = YES;
                 } else {
-                    KCLogError(@"The event could not be inserted for some reason.  Error name and description: %@, %@",
-                               errorCode,
-                               [errorDict objectForKey:kKeenDescriptionParam]);
-                    deleteFile = NO;
+                    errorDescription =
+                        [NSString stringWithFormat:@"The event could not be inserted for some reason. Will retry "
+                                                   @"during next upload if max attempts haven't been reached. Error "
+                                                   @"name and description: %@, %@",
+                                                   errorName,
+                                                   errorDict[kKeenResponseErrorDescriptionKey]];
+                    deleteEvent = NO;
                 }
+
+                KCLogError(@"%@", errorDescription);
+                [errors addObject:[NSError errorWithDomain:kKeenErrorDomain
+                                                      code:KeenErrorCodeEventUploadError
+                                                  userInfo:@{
+                                                      kKeenErrorDescriptionKey: errorDescription,
+                                                      kKeenResponseErrorNameKey: errorName,
+                                                      kKeenResponseErrorDictionaryKey: errorDict
+                                                  }]];
             }
 
             NSNumber *eid = [[eventIds objectForKey:collectionName] objectAtIndex:count];
 
             // delete the file if we need to
-            if (deleteFile) {
+            if (deleteEvent) {
                 [self.store deleteEvent:eid];
                 KCLogVerbose(@"Successfully deleted event: %@", eid);
             }
             count++;
         }
+    }
+
+    // Report any errors that occured
+    if (errors.count > 0) {
+        KCLogError(@"%@ errors while trying to upload events", @(errors.count));
+        *ppError = [NSError errorWithDomain:kKeenErrorDomain
+                                       code:KeenErrorCodeEventUploadError
+                                   userInfo:@{kKeenErrorInnerErrorArrayKey: errors}];
     }
 }
 

--- a/KeenClient/KIOUtil.m
+++ b/KeenClient/KIOUtil.m
@@ -83,7 +83,7 @@
         const id objects[] = {errorMessage, underlyingError};
         NSUInteger count = underlyingError ? 2 : 1;
         NSDictionary *userInfo = [NSDictionary dictionaryWithObjects:objects forKeys:keys count:count];
-        *error = [NSError errorWithDomain:kKeenErrorDomain code:1 userInfo:userInfo];
+        *error = [NSError errorWithDomain:kKeenErrorDomain code:KeenErrorCodeGeneral userInfo:userInfo];
         KCLogError(@"%@", *error);
     }
 

--- a/KeenClient/KIOUtil.m
+++ b/KeenClient/KIOUtil.m
@@ -96,7 +96,7 @@
     NSDateFormatter *dateFormatter = [NSDateFormatter new];
     NSLocale *enUSPOSIXLocale = [NSLocale localeWithLocaleIdentifier:@"en_US_POSIX"];
     [dateFormatter setLocale:enUSPOSIXLocale];
-    [dateFormatter setDateFormat:@"yyyy-MM-dd'T'HH:mm:ssZZZZZ"];
+    [dateFormatter setDateFormat:@"yyyy-MM-dd'T'HH:mm:ss.SSSZZZZZ"];
 
     NSString *iso8601String = [dateFormatter stringFromDate:date];
     return iso8601String;

--- a/KeenClient/KeenClient.m
+++ b/KeenClient/KeenClient.m
@@ -428,7 +428,7 @@ static BOOL geoLocationRequestEnabled = YES;
             errorMessage = @"You must specify a non-null, non-empty event.";
             return [KIOUtil handleError:anError withErrorMessage:errorMessage];
         }
-        id keenObject = [event objectForKey:@"keen"];
+        id keenObject = event[kKeenEventKeenDataKey];
         if (keenObject && ![keenObject isKindOfClass:[NSDictionary class]]) {
             errorMessage = @"An event's root-level property named 'keen' must be a dictionary.";
             return [KIOUtil handleError:anError withErrorMessage:errorMessage];
@@ -530,15 +530,15 @@ static BOOL geoLocationRequestEnabled = YES;
     NSMutableDictionary *eventToWrite = [NSMutableDictionary dictionaryWithDictionary:event];
 
     // either set "keen" only from keen properties or merge in
-    NSDictionary *originalKeenDict = [eventToWrite objectForKey:@"keen"];
+    NSDictionary *originalKeenDict = eventToWrite[kKeenEventKeenDataKey];
     if (originalKeenDict) {
         // have to merge
         NSMutableDictionary *keenDict = [KIOUtil handleInvalidJSONInObject:keenProperties];
         [keenDict addEntriesFromDictionary:originalKeenDict];
-        [eventToWrite setObject:keenDict forKey:@"keen"];
+        eventToWrite[kKeenEventKeenDataKey] = keenDict;
     } else {
         // just set it directly
-        [eventToWrite setObject:keenProperties forKey:@"keen"];
+        eventToWrite[kKeenEventKeenDataKey] = keenProperties;
     }
 
     NSError *serializationError;
@@ -565,6 +565,10 @@ static BOOL geoLocationRequestEnabled = YES;
 
 - (void)uploadWithFinishedBlock:(void (^)())block {
     [self.uploader uploadEventsForConfig:self.config completionHandler:block];
+}
+
+- (void)uploadWithCompletionHandler:(UploadCompletionBlock)completionHandler {
+    [self.uploader uploadEventsForConfig:self.config completionHandler:completionHandler];
 }
 
 #pragma mark - Querying

--- a/KeenClient/KeenConstants.h
+++ b/KeenClient/KeenConstants.h
@@ -42,7 +42,7 @@ extern NSString *const kKeenErrorDomain;
 
 // Error codes for NSError
 // clang-format off
-NS_ENUM(NSInteger, KeenErrorCode) {
+typedef NS_ENUM(NSInteger, KeenErrorCode) {
     KeenErrorCodeGeneral = 1,
     KeenErrorCodeNetworkDisconnected = 2,
     KeenErrorCodeSerialization = 3,

--- a/KeenClient/KeenConstants.h
+++ b/KeenClient/KeenConstants.h
@@ -10,25 +10,65 @@
 
 #define kKeenSdkVersion @"3.7.0"
 
-extern NSString * const kKeenApiUrlScheme;
-extern NSString * const kKeenDefaultApiUrlAuthority;
-extern NSString * const kKeenApiVersion;
+// Keen API constants
 
-extern NSString * const kKeenNameParam;
-extern NSString * const kKeenDescriptionParam;
-extern NSString * const kKeenSuccessParam;
-extern NSString * const kKeenErrorParam;
-extern NSString * const kKeenErrorCodeParam;
-extern NSString * const kKeenInvalidCollectionNameError;
-extern NSString * const kKeenInvalidPropertyNameError;
-extern NSString * const kKeenInvalidPropertyValueError;
+extern NSString *const kKeenApiUrlScheme;
+extern NSString *const kKeenDefaultApiUrlAuthority;
+extern NSString *const kKeenApiVersion;
 
+extern NSString *const kKeenResponseErrorNameKey;
+extern NSString *const kKeenResponseErrorDescriptionKey;
+extern NSString *const kKeenSuccessParam;
+extern NSString *const kKeenResponseErrorDictionaryKey;
+extern NSString *const kKeenErrorCodeParam;
+extern NSString *const kKeenInvalidCollectionNameError;
+extern NSString *const kKeenInvalidPropertyNameError;
+extern NSString *const kKeenInvalidPropertyValueError;
+
+// The key on an event dictionary for keen-provided data
+extern NSString *const kKeenEventKeenDataKey;
+
+// A key containing the number of upload attempts for a given event
+extern NSString *const kKeenEventKeenDataAttemptsKey;
+
+// how many events can be stored for a single collection before aging them out
 extern NSUInteger const kKeenMaxEventsPerCollection;
+
+// how many events to drop when aging out
 extern NSUInteger const kKeenNumberEventsToForget;
 
-extern NSString * const kKeenErrorDomain;
+// custom domain for NSErrors
+extern NSString *const kKeenErrorDomain;
 
-extern NSString * const kKeenSdkVersionHeader;
-extern NSString * const kKeenSdkVersionWithPlatform;
+// Error codes for NSError
+// clang-format off
+NS_ENUM(NSInteger, KeenErrorCode) {
+    KeenErrorCodeGeneral = 1,
+    KeenErrorCodeNetworkDisconnected = 2,
+    KeenErrorCodeSerialization = 3,
+    KeenErrorCodeResponseError = 4,
+    KeenErrorCodeEventUploadError = 6
+};
+// clang-format on
 
-extern NSString * const kKeenFileStoreImportedKey;
+// Key in NSError userInfo used for storing an instance of an NSError returned
+// from an underlying API call
+extern NSString *const kKeenErrorInnerErrorKey;
+
+// Key in NSError userInfo used for storing an NSArray of underlying NSErrors
+extern NSString *const kKeenErrorInnerErrorArrayKey;
+
+// Key in NSError userInfo used for error descriptions
+extern NSString *const kKeenErrorDescriptionKey;
+
+// Key in NSError userInfo used for http status codes
+extern NSString *const kKeenErrorHttpStatus;
+
+// Name of header that provides SDK version info
+extern NSString *const kKeenSdkVersionHeader;
+
+// The SDK version info header content.
+extern NSString *const kKeenSdkVersionWithPlatform;
+
+// User settings key indicating that a file store import has already been done.
+extern NSString *const kKeenFileStoreImportedKey;

--- a/KeenClient/KeenConstants.m
+++ b/KeenClient/KeenConstants.m
@@ -12,31 +12,35 @@ NSString *const kKeenApiUrlScheme = @"https";
 NSString *const kKeenDefaultApiUrlAuthority = @"api.keen.io";
 NSString *const kKeenApiVersion = @"3.0";
 
-// Keen API constants
-
-NSString *const kKeenNameParam = @"name";
-NSString *const kKeenDescriptionParam = @"description";
+NSString *const kKeenResponseErrorNameKey = @"name";
+NSString *const kKeenResponseErrorDescriptionKey = @"description";
 NSString *const kKeenSuccessParam = @"success";
-NSString *const kKeenErrorParam = @"error";
+NSString *const kKeenResponseErrorDictionaryKey = @"error";
 NSString *const kKeenErrorCodeParam = @"error_code";
 NSString *const kKeenInvalidCollectionNameError = @"InvalidCollectionNameError";
 NSString *const kKeenInvalidPropertyNameError = @"InvalidPropertyNameError";
 NSString *const kKeenInvalidPropertyValueError = @"InvalidPropertyValueError";
 
-// Keen constants related to how much data we'll cache on the device before aging it out
+NSString *const kKeenEventKeenDataKey = @"keen";
 
-// how many events can be stored for a single collection before aging them out
+NSString *const kKeenEventKeenDataAttemptsKey = @"prior_attempts";
+
 NSUInteger const kKeenMaxEventsPerCollection = 10000;
-// how many events to drop when aging out
+
 NSUInteger const kKeenNumberEventsToForget = 100;
 
-// custom domain for NSErrors
 NSString *const kKeenErrorDomain = @"io.keen";
 
-// Name of header that provides SDK version info
+NSString *const kKeenErrorInnerErrorKey = @"InnerError";
+
+NSString *const kKeenErrorInnerErrorArrayKey = @"InnerErrorArray";
+
+NSString *const kKeenErrorDescriptionKey = @"Description";
+
+NSString *const kKeenErrorHttpStatus = @"HTTPStatus";
+
 NSString *const kKeenSdkVersionHeader = @"Keen-Sdk";
-// The SDK version info header content.
+
 NSString *const kKeenSdkVersionWithPlatform = @"ios-" kKeenSdkVersion;
 
-// User settings key indicating that a file store import has already been done.
 NSString *const kKeenFileStoreImportedKey = @"didFSImport";

--- a/KeenClient/KeenConstants.m
+++ b/KeenClient/KeenConstants.m
@@ -23,7 +23,7 @@ NSString *const kKeenInvalidPropertyValueError = @"InvalidPropertyValueError";
 
 NSString *const kKeenEventKeenDataKey = @"keen";
 
-NSString *const kKeenEventKeenDataAttemptsKey = @"prior_attempts";
+NSString *const kKeenEventKeenDataAttemptsKey = @"keen_prior_upload_attempts";
 
 NSUInteger const kKeenMaxEventsPerCollection = 10000;
 

--- a/KeenClientTests/GlobalPropertiesTests.m
+++ b/KeenClientTests/GlobalPropertiesTests.m
@@ -9,6 +9,7 @@
 #import "KeenClient.h"
 
 #import "KeenTestConstants.h"
+#import "KeenConstants.h"
 #import "KeenClientTestable.h"
 
 #import "GlobalPropertiesTests.h"
@@ -31,7 +32,7 @@
                 [[KIODBStore.sharedInstance getEventsWithMaxAttempts:3 andProjectID:client.config.projectID]
                     objectForKey:eventCollectionName];
             // Grab the first event we get back
-            NSData *eventData = [eventsForCollection objectForKey:[[eventsForCollection allKeys] objectAtIndex:0]];
+            NSData *eventData = eventsForCollection[[eventsForCollection allKeys][0]][@"data"];
             NSError *error = nil;
             NSDictionary *storedEvent = [NSJSONSerialization JSONObjectWithData:eventData options:0 error:&error];
 
@@ -56,7 +57,7 @@
 
     // a dictionary that contains an addon should be okay
     NSDictionary *theEvent = @{
-        @"keen": @{
+        kKeenEventKeenDataKey: @{
             @"addons": @[@{
                 @"name": @"addon:name",
                 @"input": @{@"param_name": @"property_that_contains_param"},
@@ -66,7 +67,7 @@
         @"a": @"b"
     };
     storedEvent = RunTest(theEvent, 2);
-    NSDictionary *deserializedAddon = storedEvent[@"keen"][@"addons"][0];
+    NSDictionary *deserializedAddon = storedEvent[kKeenEventKeenDataKey][@"addons"][0];
     XCTAssertEqualObjects(@"addon:name", deserializedAddon[@"name"], @"Addon name should be right");
 }
 
@@ -86,7 +87,7 @@
                 [[KIODBStore.sharedInstance getEventsWithMaxAttempts:3 andProjectID:client.config.projectID]
                     objectForKey:eventCollectionName];
             // Grab the first event we get back
-            NSData *eventData = [eventsForCollection objectForKey:[[eventsForCollection allKeys] objectAtIndex:0]];
+            NSData *eventData = eventsForCollection[[eventsForCollection allKeys][0]][@"data"];
             NSError *error = nil;
             NSDictionary *storedEvent = [NSJSONSerialization JSONObjectWithData:eventData options:0 error:&error];
 
@@ -111,7 +112,7 @@
 
     // a dictionary that contains an addon should be okay
     NSDictionary *theEvent = @{
-        @"keen": @{
+        kKeenEventKeenDataKey: @{
             @"addons": @[@{
                 @"name": @"addon:name",
                 @"input": @{@"param_name": @"property_that_contains_param"},
@@ -121,7 +122,7 @@
         @"a": @"b"
     };
     storedEvent = RunTest(theEvent, 2);
-    NSDictionary *deserializedAddon = storedEvent[@"keen"][@"addons"][0];
+    NSDictionary *deserializedAddon = storedEvent[kKeenEventKeenDataKey][@"addons"][0];
     XCTAssertEqualObjects(@"addon:name", deserializedAddon[@"name"], @"Addon name should be right");
 }
 
@@ -142,7 +143,7 @@
                 [[KIODBStore.sharedInstance getEventsWithMaxAttempts:3 andProjectID:client.config.projectID]
                     objectForKey:eventCollectionName];
             // Grab the first event we get back
-            NSData *eventData = [eventsForCollection objectForKey:[[eventsForCollection allKeys] objectAtIndex:0]];
+            NSData *eventData = eventsForCollection[[eventsForCollection allKeys][0]][@"data"];
             NSError *error = nil;
             NSDictionary *storedEvent = [NSJSONSerialization JSONObjectWithData:eventData options:0 error:&error];
 
@@ -178,7 +179,7 @@
 
     // a dictionary that contains an addon should be okay
     NSDictionary *theEvent = @{
-        @"keen": @{
+        kKeenEventKeenDataKey: @{
             @"addons": @[@{
                 @"name": @"addon:name",
                 @"input": @{@"param_name": @"property_that_contains_param"},
@@ -192,7 +193,7 @@
             return theEvent;
         },
         2);
-    NSDictionary *deserializedAddon = storedEvent[@"keen"][@"addons"][0];
+    NSDictionary *deserializedAddon = storedEvent[kKeenEventKeenDataKey][@"addons"][0];
     XCTAssertEqualObjects(@"addon:name", deserializedAddon[@"name"], @"Addon name should be right");
 }
 
@@ -213,7 +214,7 @@
                 [[KIODBStore.sharedInstance getEventsWithMaxAttempts:3 andProjectID:client.config.projectID]
                     objectForKey:eventCollectionName];
             // Grab the first event we get back
-            NSData *eventData = [eventsForCollection objectForKey:[[eventsForCollection allKeys] objectAtIndex:0]];
+            NSData *eventData = eventsForCollection[[eventsForCollection allKeys][0]][@"data"];
             NSError *error = nil;
             NSDictionary *storedEvent = [NSJSONSerialization JSONObjectWithData:eventData options:0 error:&error];
 
@@ -249,7 +250,7 @@
 
     // a dictionary that contains an addon should be okay
     NSDictionary *theEvent = @{
-        @"keen": @{
+        kKeenEventKeenDataKey: @{
             @"addons": @[@{
                 @"name": @"addon:name",
                 @"input": @{@"param_name": @"property_that_contains_param"},
@@ -263,7 +264,7 @@
             return theEvent;
         },
         2);
-    NSDictionary *deserializedAddon = storedEvent[@"keen"][@"addons"][0];
+    NSDictionary *deserializedAddon = storedEvent[kKeenEventKeenDataKey][@"addons"][0];
     XCTAssertEqualObjects(@"addon:name", deserializedAddon[@"name"], @"Addon name should be right");
 }
 
@@ -285,7 +286,7 @@
         [[KIODBStore.sharedInstance getEventsWithMaxAttempts:3 andProjectID:client.config.projectID]
             objectForKey:@"apples"];
     // Grab the first event we get back
-    NSData *eventData = [eventsForCollection objectForKey:[[eventsForCollection allKeys] objectAtIndex:0]];
+    NSData *eventData = eventsForCollection[[eventsForCollection allKeys][0]][@"data"];
     NSError *error = nil;
     NSDictionary *storedEvent = [NSJSONSerialization JSONObjectWithData:eventData options:0 error:&error];
 
@@ -312,7 +313,7 @@
         [[KIODBStore.sharedInstance getEventsWithMaxAttempts:3 andProjectID:client.config.projectID]
             objectForKey:@"apples"];
     // Grab the first event we get back
-    NSData *eventData = [eventsForCollection objectForKey:[[eventsForCollection allKeys] objectAtIndex:0]];
+    NSData *eventData = eventsForCollection[[eventsForCollection allKeys][0]][@"data"];
     NSError *error = nil;
     NSDictionary *storedEvent = [NSJSONSerialization JSONObjectWithData:eventData options:0 error:&error];
 

--- a/KeenClientTests/KeenClientTests.m
+++ b/KeenClientTests/KeenClientTests.m
@@ -88,8 +88,8 @@
                                                    andWriteKey:kDefaultWriteKey
                                                     andReadKey:kDefaultReadKey];
     XCTAssertEqualObjects(
-                          kKeenDefaultApiUrlAuthority, client.config.apiUrlAuthority, @"Should set default API URL authority");
-    
+        kKeenDefaultApiUrlAuthority, client.config.apiUrlAuthority, @"Should set default API URL authority");
+
     NSString *customAuthority = @"some.url.com";
     KeenClient *client2 = [[KeenClient alloc] initWithProjectID:kDefaultProjectID
                                                     andWriteKey:kDefaultWriteKey
@@ -103,8 +103,8 @@
                                                    andWriteKey:kDefaultWriteKey
                                                     andReadKey:kDefaultReadKey];
     XCTAssertEqualObjects(
-                          kKeenDefaultApiUrlAuthority, client.config.apiUrlAuthority, @"Should set default API URL authority");
-    
+        kKeenDefaultApiUrlAuthority, client.config.apiUrlAuthority, @"Should set default API URL authority");
+
     NSString *customAuthority = @"some.url.com";
     KeenClient *client2 = [KeenClient sharedClientWithProjectID:kDefaultProjectID
                                                     andWriteKey:kDefaultWriteKey
@@ -122,7 +122,7 @@
                                                      andReadKey:kDefaultReadKey];
 
     NSDictionary *theEvent = @{
-        @"keen": @{
+        kKeenEventKeenDataKey: @{
             @"addons": @[@{
                 @"name": @"addon:name",
                 @"input": @{@"param_name": @"property_that_contains_param"},
@@ -143,10 +143,10 @@
         [[KIODBStore.sharedInstance getEventsWithMaxAttempts:3 andProjectID:client.config.projectID]
             objectForKey:@"foo"];
     // Grab the first event we get back
-    NSData *eventData = [eventsForCollection objectForKey:[[eventsForCollection allKeys] objectAtIndex:0]];
+    NSData *eventData = eventsForCollection[[eventsForCollection allKeys][0]][@"data"];
     NSDictionary *deserializedDict = [NSJSONSerialization JSONObjectWithData:eventData options:0 error:&error];
 
-    NSDictionary *deserializedAddon = deserializedDict[@"keen"][@"addons"][0];
+    NSDictionary *deserializedAddon = deserializedDict[kKeenEventKeenDataKey][@"addons"][0];
     XCTAssertEqualObjects(@"addon:name", deserializedAddon[@"name"], @"Addon name should be right");
 }
 
@@ -235,7 +235,8 @@
     XCTAssertNil(error);
 
     XCTestExpectation *uploadFinished = [self expectationWithDescription:@"upload finished"];
-    [client uploadWithFinishedBlock:^{
+    [client uploadWithCompletionHandler:^(NSError *error) {
+        XCTAssertNil(error);
         [uploadFinished fulfill];
     }];
 
@@ -254,7 +255,8 @@
     XCTAssertNil(error);
 
     XCTestExpectation *secondUploadFinished = [self expectationWithDescription:@"second upload finished"];
-    [client uploadWithFinishedBlock:^{
+    [client uploadWithCompletionHandler:^(NSError *error) {
+        XCTAssertNil(error);
         [secondUploadFinished fulfill];
     }];
 

--- a/KeenClientTests/KeenGeoLocationTests.m
+++ b/KeenClientTests/KeenGeoLocationTests.m
@@ -10,6 +10,7 @@
 #import "KeenClientTestable.h"
 #import "KeenTestConstants.h"
 #import "KeenGeoLocationTests.h"
+#import "KeenConstants.h"
 
 @implementation KeenGeoLocationTests
 
@@ -33,11 +34,11 @@
         [[KIODBStore.sharedInstance getEventsWithMaxAttempts:3 andProjectID:client.config.projectID]
             objectForKey:@"foo"];
     // Grab the first event we get back
-    NSData *eventData = [eventsForCollection objectForKey:[[eventsForCollection allKeys] objectAtIndex:0]];
+    NSData *eventData = eventsForCollection[[eventsForCollection allKeys][0]][@"data"];
     NSError *error = nil;
     NSDictionary *deserializedDict = [NSJSONSerialization JSONObjectWithData:eventData options:0 error:&error];
 
-    NSDictionary *deserializedLocation = deserializedDict[@"keen"][@"location"];
+    NSDictionary *deserializedLocation = deserializedDict[kKeenEventKeenDataKey][@"location"];
     NSArray *deserializedCoords = deserializedLocation[@"coordinates"];
     XCTAssertEqualObjects(@-122.47, deserializedCoords[0], @"Longitude was incorrect.");
     XCTAssertEqualObjects(@37.73, deserializedCoords[1], @"Latitude was incorrect.");
@@ -63,11 +64,11 @@
         [[KIODBStore.sharedInstance getEventsWithMaxAttempts:3 andProjectID:client.config.projectID]
             objectForKey:@"bar"];
     // Grab the first event we get back
-    NSData *eventData = [eventsForCollection objectForKey:[[eventsForCollection allKeys] objectAtIndex:0]];
+    NSData *eventData = eventsForCollection[[eventsForCollection allKeys][0]][@"data"];
     NSError *error = nil;
     NSDictionary *deserializedDict = [NSJSONSerialization JSONObjectWithData:eventData options:0 error:&error];
 
-    NSDictionary *deserializedLocation = deserializedDict[@"keen"][@"location"];
+    NSDictionary *deserializedLocation = deserializedDict[kKeenEventKeenDataKey][@"location"];
     XCTAssertNil(deserializedLocation, @"No location should have been saved.");
 }
 
@@ -91,11 +92,11 @@
         [[KIODBStore.sharedInstance getEventsWithMaxAttempts:3 andProjectID:client.config.projectID]
             objectForKey:@"bar"];
     // Grab the first event we get back
-    NSData *eventData = [eventsForCollection objectForKey:[[eventsForCollection allKeys] objectAtIndex:0]];
+    NSData *eventData = eventsForCollection[[eventsForCollection allKeys][0]][@"data"];
     NSError *error = nil;
     NSDictionary *deserializedDict = [NSJSONSerialization JSONObjectWithData:eventData options:0 error:&error];
 
-    NSDictionary *deserializedLocation = deserializedDict[@"keen"][@"location"];
+    NSDictionary *deserializedLocation = deserializedDict[kKeenEventKeenDataKey][@"location"];
     XCTAssertNil(deserializedLocation, @"No location should have been saved.");
 
     // To properly test this, you want to make sure that this triggers a real location authentication request,

--- a/KeenClientTests/MockNSURLSession.h
+++ b/KeenClientTests/MockNSURLSession.h
@@ -10,12 +10,13 @@
 
 @interface MockNSURLSession : NSObject
 
-- (instancetype)initWithValidator:(BOOL (^)(id requestObject))validator data:(NSData *)data response:(NSURLResponse *)response error:(NSError *)error;
+- (instancetype)initWithValidator:(BOOL (^)(id requestObject))validator
+                             data:(NSData *)data
+                         response:(NSURLResponse *)response
+                            error:(NSError *)error;
 
 - (NSURLSessionDataTask *)dataTaskWithRequest:(NSURLRequest *)request
-                            completionHandler:(void (^)(NSData *_Nullable data,
-                                                        NSURLResponse *_Nullable response,
-                                                        NSError *_Nullable error))completionHandler;
+                            completionHandler:
+                                (void (^)(NSData *data, NSURLResponse *response, NSError *error))completionHandler;
 
 @end
-

--- a/KeenClientTests/SdkTrackingHeaderTests.m
+++ b/KeenClientTests/SdkTrackingHeaderTests.m
@@ -45,7 +45,8 @@
 
     XCTestExpectation *responseArrived = [self expectationWithDescription:@"response of async request has arrived"];
     // and "upload" it
-    [client uploadWithFinishedBlock:^{
+    [client uploadWithCompletionHandler:^(NSError *error) {
+        XCTAssertNil(error);
         [responseArrived fulfill];
     }];
 


### PR DESCRIPTION
Add `uploadWithCompletionHandler:(void(^)(NSError *)`, which reports upload errors to clients.

Also add a `keen.prior_attempts` property to events so it's obvious if an event was upload because of a retry.

The `keen.timestamp` property now also includes millisecond values.

This change also removes a bunch of redundant tests, adds a few new constants where appropriate, provides better names for some constants, uses the more concise indexing operator [] for dictionaries and arrays where code has been modified, and adds new error codes for upload related errors.

Fixes #237